### PR TITLE
(PE-11434) Update README.md for trapperkeeper-authorization

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: clojure
 lein: lein2
 jdk:
-- oraclejdk7
-- openjdk7
+  - oraclejdk7
+  - openjdk7
+script: ./ext/travisci/test.sh
+notifications:
+  email: false

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,9 @@
+# How to contribute
+
+Third-party patches are essential for keeping Puppet Labs open-source projects
+great. We want to keep it as easy as possible to contribute changes that
+allow you to get the most out of our projects. There are a few guidelines
+that we need contributors to follow so that we can have a chance of keeping on
+top of things.  For more info, see our canonical guide to contributing:
+
+[https://github.com/puppetlabs/puppet/blob/master/CONTRIBUTING.md](https://github.com/puppetlabs/puppet/blob/master/CONTRIBUTING.md)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Trapperkeeper-authorization
 
-[![Build Status](https://travis-ci.org/masterzen/trapperkeeper-authorization.svg?branch=master)](https://travis-ci.org/puppetlabs/trapperkeeper-authorization)
+[![Build Status](https://travis-ci.org/puppetlabs/trapperkeeper-authorization.svg?branch=master)](https://travis-ci.org/puppetlabs/trapperkeeper-authorization)
 
 This clojure project is an authorization service for PuppetLabs Trapperkeeper.
 It aims to port Puppet's `auth.conf` feature to clojure, along with a different
@@ -48,14 +48,14 @@ matches an incoming request with a discrete rule.
 
 ## ACE
 
-This library supports several 2 types of entries:
+This library supports two types of entries:
 
 * `allow`: if the entry matches the incoming request identity, then the request will be allowed access
 * `deny`: if the entry matches the incoming request identity, then the resource access will be denied
 
 A third type is planned, something akin to Puppet's `allow any` behavior which
 is commonly used to authorize unauthenticated requests, which is common when
-bootstrapping a puppet agent that does not yet posses a valid client SSL
+bootstrapping a puppet agent that does not yet possess a valid client SSL
 certificate.
 
 ### Restricting access by name
@@ -138,3 +138,10 @@ Alongside with the programmatic access, this service also supports
 authorization files in typical Trapperkeeper configuration file formats.  This
 format and specification is currently evolving, see SERVER-111 for more
 information about the format and expression of authorization rules.
+
+# Support
+
+We use the [Trapperkeeper project on
+JIRA](https://tickets.puppetlabs.com/browse/TK) for tickets on the
+Trapperkeeper Authorization Service, although Github issues are welcome too.
+Please note that the best method to get our attention on an issue is via JIRA.

--- a/ext/travisci/test.sh
+++ b/ext/travisci/test.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+lein2 test


### PR DESCRIPTION
Without this patch the README documents Brice's library.  The information is
good, but is quickly growing out of sync with reality as we reform the library
into a TK service.

This patch addresses the problem by re-synchronizing with what we've decided to
do so far.

(PE-11434) Enable travisci as per tk-webserver-jetty9

Configuration copied from trapperkeeper-webserver-jetty9 master branch at
ee86ab0
