### PR TITLE
(TK-258) Config checking and transformation functions

### DIFF
--- a/dev-resources/puppetlabs/trapperkeeper/services/authorization/auth.conf
+++ b/dev-resources/puppetlabs/trapperkeeper/services/authorization/auth.conf
@@ -1,0 +1,15 @@
+authorization: {
+ rules: [
+ {
+   path: /path/to/resource
+   type: path
+   allow: [ "*.domain.org", "*.test.com" ]
+   deny: "bad.guy.com"
+ },
+ {
+   type: regex
+   path: "(incoming|outgoing)"
+   allow: "www.domain.org"
+ }
+ ]
+}

--- a/project.clj
+++ b/project.clj
@@ -33,11 +33,9 @@
   ;; code that we have.
   :classifiers [["test" :testutils]]
 
-  :profiles {:dev {:dependencies [[spyscope "0.1.4"]
-                                  [puppetlabs/trapperkeeper ~tk-version :classifier "test" :scope "test"]
+  :profiles {:dev {:dependencies [[puppetlabs/trapperkeeper ~tk-version :classifier "test" :scope "test"]
                                   [puppetlabs/trapperkeeper-webserver-jetty9 ~tk-jetty-version :classifier "test"]
-                                  [puppetlabs/kitchensink "1.0.0" :classifier "test"]]
-                   :injections [(require 'spyscope.core)]}
+                                  [puppetlabs/kitchensink "1.0.0" :classifier "test"]]}
              :testutils {:source-paths ^:replace ["test"]}}
 
   ;; this plugin is used by jenkins jobs to interrogate the project version

--- a/project.clj
+++ b/project.clj
@@ -1,3 +1,5 @@
+(def tk-version "1.1.1")
+(def tk-jetty-version "1.3.1")
 (def tk-authz-version "0.0.1")
 
 (defproject masterzen/trapperkeeper-authorization tk-authz-version
@@ -12,15 +14,17 @@
   :pedantic? :abort
 
   :dependencies [[org.clojure/clojure "1.6.0"]
+                 [puppetlabs/trapperkeeper ~tk-version]
+                 [puppetlabs/trapperkeeper-webserver-jetty9 ~tk-jetty-version]
                  ;; Logging
                  [org.clojure/tools.logging "0.2.6"]
                  ;; Filesystem utilities
                  [me.raynes/fs "1.4.5"]
                  [org.clojure/tools.cli "0.3.0"]
-                 [prismatic/schema "0.2.2"]
+                 [prismatic/schema "0.4.0"]
                  [inet.data "0.5.5"]
                  [clj-time "0.5.1"]
-                 [puppetlabs/typesafe-config "0.1.1"]
+                 [puppetlabs/typesafe-config "0.1.4"]
                  [puppetlabs/ssl-utils "0.8.0"]]
 
   ;; By declaring a classifier here and a corresponding profile below we'll get an additional jar
@@ -30,6 +34,8 @@
   :classifiers [["test" :testutils]]
 
   :profiles {:dev {:dependencies [[spyscope "0.1.4"]
+                                  [puppetlabs/trapperkeeper ~tk-version :classifier "test" :scope "test"]
+                                  [puppetlabs/trapperkeeper-webserver-jetty9 ~tk-jetty-version :classifier "test"]
                                   [puppetlabs/kitchensink ~"1.0.0" :classifier "test"]]
                    :injections [(require 'spyscope.core)]}
              :testutils {:source-paths ^:replace ["test"]}}

--- a/project.clj
+++ b/project.clj
@@ -2,9 +2,9 @@
 (def tk-jetty-version "1.3.1")
 (def tk-authz-version "0.0.1")
 
-(defproject masterzen/trapperkeeper-authorization tk-authz-version
+(defproject puppetlabs/trapperkeeper-authorization tk-authz-version
   :description "TrapperKeeper authorization system"
-  :url "http://github.com/masterzen/trapperkeeper-authorization"
+  :url "http://github.com/puppetlabs/trapperkeeper-authorization"
   :license {:name "Apache License, Version 2.0"
             :url "http://www.apache.org/licenses/LICENSE-2.0.html"}
 

--- a/project.clj
+++ b/project.clj
@@ -36,7 +36,7 @@
   :profiles {:dev {:dependencies [[spyscope "0.1.4"]
                                   [puppetlabs/trapperkeeper ~tk-version :classifier "test" :scope "test"]
                                   [puppetlabs/trapperkeeper-webserver-jetty9 ~tk-jetty-version :classifier "test"]
-                                  [puppetlabs/kitchensink ~"1.0.0" :classifier "test"]]
+                                  [puppetlabs/kitchensink "1.0.0" :classifier "test"]]
                    :injections [(require 'spyscope.core)]}
              :testutils {:source-paths ^:replace ["test"]}}
 

--- a/project.clj
+++ b/project.clj
@@ -23,9 +23,9 @@
                  [org.clojure/tools.cli "0.3.0"]
                  [prismatic/schema "0.4.0"]
                  [inet.data "0.5.5"]
-                 [clj-time "0.5.1"]
+                 [clj-time "0.7.0"]
                  [puppetlabs/typesafe-config "0.1.4"]
-                 [puppetlabs/ssl-utils "0.8.0"]]
+                 [puppetlabs/ssl-utils "0.8.1"]]
 
   ;; By declaring a classifier here and a corresponding profile below we'll get an additional jar
   ;; during `lein jar` that has all the code in the test/ directory. Downstream projects can then

--- a/src/puppetlabs/trapperkeeper/authorization/rules.clj
+++ b/src/puppetlabs/trapperkeeper/authorization/rules.clj
@@ -2,7 +2,7 @@
   (:require [schema.core :as schema]
             [puppetlabs.trapperkeeper.authorization.acl :as acl]
             [puppetlabs.trapperkeeper.authorization.ring :refer [Request]])
-(:import java.util.regex.Pattern))
+  (:import java.util.regex.Pattern))
 
 ;; Schemas
 

--- a/src/puppetlabs/trapperkeeper/services/authorization/authorization_core.clj
+++ b/src/puppetlabs/trapperkeeper/services/authorization/authorization_core.clj
@@ -15,7 +15,7 @@
 
 (def required-or-key
   "At least one of these keys is required in an auth rule map."
-  [:deny :allow])
+  #{:deny :allow})
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Private

--- a/src/puppetlabs/trapperkeeper/services/authorization/authorization_core.clj
+++ b/src/puppetlabs/trapperkeeper/services/authorization/authorization_core.clj
@@ -1,0 +1,126 @@
+(ns puppetlabs.trapperkeeper.services.authorization.authorization-core
+  (:require [clojure.string :as str]
+            [puppetlabs.kitchensink.core :as ks]
+            [schema.core :as schema]
+            [puppetlabs.trapperkeeper.authorization.rules :as rules]
+            [puppetlabs.trapperkeeper.authorization.acl :as acl])
+  (:import (java.util.regex PatternSyntaxException)))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; Constants
+
+(def required-keys
+  "Keys required in an auth rule map."
+  [:path :type])
+
+(def required-or-key
+  "At least one of these keys is required in an auth rule map."
+  [:deny :allow])
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; Private
+
+(defn pprint-rule
+  [rule]
+  (str/trim (ks/pprint-to-string rule)))
+
+
+(schema/defn transform-config-rule-to-acl :- acl/ACL
+  [{:keys [allow deny] :as config-rule}]
+  (let [type (if (= "regex" (.toLowerCase (:type config-rule)))
+               :regex :domain)
+        base {:qualifier :exact
+              :length nil
+              :type type}
+        allow-base (assoc base :auth-type :allow)
+        deny-base (assoc base :auth-type :deny)
+        allow (if (string? allow) [allow] allow)
+        deny (if (string? deny) [deny] deny)]
+    (set (concat
+           (map #(assoc allow-base :pattern %) allow)
+           (map #(assoc deny-base :pattern %) deny)))))
+
+(schema/defn transform-config-rule :- rules/Rule
+  [config-rule]
+  (let [type (name (.toLowerCase (:type config-rule)))]
+    {:type (if (= type "regex") :regex :string)
+     :path (re-pattern (:path config-rule))
+     :method :any
+     :acl (transform-config-rule-to-acl config-rule)}))
+
+(defn validate-auth-config-rule!
+  "Tests to see if the given map contains the proper data to define an auth
+  rule. Returns the provided rule if successful, otherwise throws an exception
+  with a useful error message."
+  [rule]
+  (when-not (map? rule)
+    (throw (IllegalArgumentException. "An authorization rule should be specified as a map")))
+  (let [rule-keys (keys rule)]
+    (doseq [k required-keys]
+      (when-not (some #(= k %) rule-keys)
+        (throw (IllegalArgumentException. (str "The authorization rule specified as "
+                                               (pprint-rule rule)
+                                               " does not contain a '" (name k) "' key.")))))
+    (when-not (some #(.contains required-or-key %) rule-keys)
+      (throw (IllegalArgumentException.
+               (str "Authorization rule specified as  "
+                    (pprint-rule rule)
+                    " must contain either a 'deny' or 'allow' rule.")))))
+  (when-not (string? (:type rule))
+    (throw (IllegalArgumentException.
+             (str "The type set in the authorization rule specified "
+                  "as " (pprint-rule rule) " should be a "
+                  "string that is either 'path' or 'regex'."))))
+  (let [type (.toLowerCase (:type rule))]
+    (when-not (or (= type "path") (= type "regex"))
+      (throw (IllegalArgumentException.
+               (str "The type set in the authorization rule specified "
+                    "as " (pprint-rule rule) " is invalid. "
+                    "It should be set to either 'path' or 'regex'.")))))
+  (let [{path :path} rule]
+    (when-not (string? path)
+      (throw (IllegalArgumentException.
+               (str "The path set in the authorization rule specified as "
+                    (pprint-rule rule) " is invalid. It should be "
+                    "a string.")))))
+  (when (= (name (:type rule)) "regex")
+    (try
+      (re-pattern (:path rule))
+      (catch PatternSyntaxException e
+        (throw (IllegalArgumentException.
+                 (str "The path regex provided in the rule defined as "
+                      (pprint-rule rule) " is invalid: "
+                      (.getMessage e)))))))
+  (doseq [[type names] (select-keys rule [:allow :deny])]
+    (if (vector? names)
+      (when-not (every? string? names)
+        (throw (IllegalArgumentException.
+                 (str "The " (name type) " list in the rule specified as "
+                      (pprint-rule rule)
+                      " contains one or more names that are not strings."))))
+      (when-not (string? names)
+        (throw (IllegalArgumentException.
+                 (str "The name '" names "' in the '" (name type) "' field of the "
+                      "rule specified as " (pprint-rule rule) " is not a string."))))))
+  rule)
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; Public
+
+(defn validate-auth-config!
+  "Validates the given authorization service configuration. If an invalid
+  configuration is found an IllegalArgumentException will be thrown, otherwise
+  the input config will be returned."
+  [config]
+  (when-not (vector? config)
+    (throw (IllegalArgumentException.
+             "The providede authorization service config is not a list.")))
+  (doseq [rule config]
+    (validate-auth-config-rule! rule))
+  config)
+
+(schema/defn transform-config :- rules/Rules
+  "Transforms the authorization service config into a list of Rules that work
+  with the authorization code."
+  [config]
+  (map transform-config-rule config))

--- a/src/puppetlabs/trapperkeeper/services/authorization/authorization_core.clj
+++ b/src/puppetlabs/trapperkeeper/services/authorization/authorization_core.clj
@@ -24,7 +24,6 @@
   [rule]
   (str/trim (ks/pprint-to-string rule)))
 
-
 (schema/defn transform-config-rule-to-acl :- acl/ACL
   [{:keys [allow deny] :as config-rule}]
   (let [type (if (= "regex" (.toLowerCase (:type config-rule)))

--- a/src/puppetlabs/trapperkeeper/services/authorization/authorization_core.clj
+++ b/src/puppetlabs/trapperkeeper/services/authorization/authorization_core.clj
@@ -34,7 +34,7 @@
 
 (schema/defn transform-config-rule :- rules/Rule
   [config-rule]
-  (let [type (name (.toLowerCase (:type config-rule)))]
+  (let [type (str/lower-case (name (:type config-rule)))]
     {:type (if (= type "regex") :regex :string)
      :path (re-pattern (:path config-rule))
      :method :any
@@ -63,7 +63,7 @@
              (str "The type set in the authorization rule specified "
                   "as " (pprint-rule rule) " should be a "
                   "string that is either 'path' or 'regex'."))))
-  (let [type (.toLowerCase (:type rule))]
+  (let [type (str/lower-case (name (:type rule)))]
     (when-not (or (= type "path") (= type "regex"))
       (throw (IllegalArgumentException.
                (str "The type set in the authorization rule specified "

--- a/src/puppetlabs/trapperkeeper/services/authorization/authorization_core.clj
+++ b/src/puppetlabs/trapperkeeper/services/authorization/authorization_core.clj
@@ -28,8 +28,8 @@
   [{:keys [allow deny]}]
   (let [allow (if (string? allow) [allow] allow)
         deny (if (string? deny) [deny] deny)]
-    (let [allow-acl (reduce #(acl/allow %1 %2) acl/empty-acl allow)
-          full-acl (reduce #(acl/deny %1 %2) allow-acl deny)]
+    (let [allow-acl (reduce acl/allow acl/empty-acl allow)
+          full-acl (reduce acl/deny allow-acl deny)]
       full-acl)))
 
 (schema/defn transform-config-rule :- rules/Rule

--- a/src/puppetlabs/trapperkeeper/services/authorization/authorization_core.clj
+++ b/src/puppetlabs/trapperkeeper/services/authorization/authorization_core.clj
@@ -106,7 +106,7 @@
   [config]
   (when-not (vector? config)
     (throw (IllegalArgumentException.
-             "The providede authorization service config is not a list.")))
+             "The provided authorization service config is not a list.")))
   (doseq [rule config]
     (validate-auth-config-rule! rule))
   config)

--- a/src/puppetlabs/trapperkeeper/services/authorization/authorization_service.clj
+++ b/src/puppetlabs/trapperkeeper/services/authorization/authorization_service.clj
@@ -19,6 +19,5 @@
 
   (wrap-with-authorization-check
     [this handler]
-    (if-let [rules (get-in (service-context this) [:rules])]
-      (wrap-authorization-check handler rules)
-      (throw (IllegalStateException. (str "ERROR: No rules loaded."))))))
+    (let [rules (get-in (service-context this) [:rules])]
+      (wrap-authorization-check handler rules))))

--- a/src/puppetlabs/trapperkeeper/services/authorization/authorization_service.clj
+++ b/src/puppetlabs/trapperkeeper/services/authorization/authorization_service.clj
@@ -1,0 +1,24 @@
+(ns puppetlabs.trapperkeeper.services.authorization.authorization-service
+  (:require [puppetlabs.trapperkeeper.core :as trapperkeeper]
+            [puppetlabs.trapperkeeper.services.authorization.authorization-core :refer :all]))
+
+(defprotocol AuthorizationService
+  (wrap-handler [this handler]))
+
+(trapperkeeper/defservice authorization-service
+  AuthorizationService
+  [[:ConfigService get-in-config]]
+  (init
+    [this context]
+    (let [config (get-in-config [:authorization :rules])]
+      (validate-auth-config! config)
+      (assoc context :authorization {:rules (transform-config config)})
+
+
+      )
+    )
+
+
+                          )
+
+

--- a/src/puppetlabs/trapperkeeper/services/authorization/authorization_service.clj
+++ b/src/puppetlabs/trapperkeeper/services/authorization/authorization_service.clj
@@ -6,7 +6,7 @@
             [puppetlabs.trapperkeeper.services.authorization.authorization-core :refer :all]))
 
 (defprotocol AuthorizationService
-  (wrap-handler [this handler]))
+  (wrap-with-authorization-check [this handler]))
 
 (defservice authorization-service
   AuthorizationService
@@ -17,7 +17,7 @@
       (validate-auth-config! config)
       (assoc-in context [:authorization :rules] (transform-config config))))
 
-  (wrap-handler
+  (wrap-with-authorization-check
     [this handler]
     (if-let [rules (get-in (service-context this) [:authorization :rules])]
       (wrap-authorization-check handler rules)

--- a/src/puppetlabs/trapperkeeper/services/authorization/authorization_service.clj
+++ b/src/puppetlabs/trapperkeeper/services/authorization/authorization_service.clj
@@ -15,10 +15,10 @@
     [this context]
     (let [config (get-in-config [:authorization :rules])]
       (validate-auth-config! config)
-      (assoc-in context [:authorization :rules] (transform-config config))))
+      (assoc-in context [:rules] (transform-config config))))
 
   (wrap-with-authorization-check
     [this handler]
-    (if-let [rules (get-in (service-context this) [:authorization :rules])]
+    (if-let [rules (get-in (service-context this) [:rules])]
       (wrap-authorization-check handler rules)
       (throw (IllegalStateException. (str "ERROR: No rules loaded."))))))

--- a/src/puppetlabs/trapperkeeper/services/authorization/authorization_service.clj
+++ b/src/puppetlabs/trapperkeeper/services/authorization/authorization_service.clj
@@ -12,13 +12,4 @@
     [this context]
     (let [config (get-in-config [:authorization :rules])]
       (validate-auth-config! config)
-      (assoc context :authorization {:rules (transform-config config)})
-
-
-      )
-    )
-
-
-                          )
-
-
+      (assoc context :authorization {:rules (transform-config config)}))))

--- a/src/puppetlabs/trapperkeeper/services/authorization/authorization_service.clj
+++ b/src/puppetlabs/trapperkeeper/services/authorization/authorization_service.clj
@@ -1,15 +1,24 @@
 (ns puppetlabs.trapperkeeper.services.authorization.authorization-service
-  (:require [puppetlabs.trapperkeeper.core :as trapperkeeper]
+  (:require [puppetlabs.trapperkeeper.core :refer [defservice]]
+            [puppetlabs.trapperkeeper.services :refer [service-context]]
+            [puppetlabs.trapperkeeper.authorization.ring-middleware :refer
+             [wrap-authorization-check]]
             [puppetlabs.trapperkeeper.services.authorization.authorization-core :refer :all]))
 
 (defprotocol AuthorizationService
   (wrap-handler [this handler]))
 
-(trapperkeeper/defservice authorization-service
+(defservice authorization-service
   AuthorizationService
   [[:ConfigService get-in-config]]
   (init
     [this context]
     (let [config (get-in-config [:authorization :rules])]
       (validate-auth-config! config)
-      (assoc context :authorization {:rules (transform-config config)}))))
+      (assoc-in context [:authorization :rules] (transform-config config))))
+
+  (wrap-handler
+    [this handler]
+    (if-let [rules (get-in (service-context this) [:authorization :rules])]
+      (wrap-authorization-check handler rules)
+      (throw (IllegalStateException. (str "ERROR: No rules loaded."))))))

--- a/test/puppetlabs/trapperkeeper/services/authorization/authorization_core_test.clj
+++ b/test/puppetlabs/trapperkeeper/services/authorization/authorization_core_test.clj
@@ -1,0 +1,93 @@
+(ns puppetlabs.trapperkeeper.services.authorization.authorization-core-test
+  (:require [clojure.test :refer :all]
+            [puppetlabs.trapperkeeper.services.authorization.authorization-core :refer :all]
+            [schema.test]))
+
+(use-fixtures :once schema.test/validate-schemas)
+
+(def base-path-auth {:path "/foo/bar/baz", :type "path"})
+(def base-regex-auth {:path "(incoming|outgoing)", :type "regex"})
+(def allow-single {:allow "www.domain.org"})
+(def allow-list {:allow ["*.domain.org" "*.test.com"]})
+(def deny-single {:deny "bald.guy.com"})
+(def deny-list {:deny ["bald.eagle.com" "bald.bull.com"]})
+
+(deftest valid-configs-pass
+  (testing "Valid forms of a auth config pass"
+    (doseq [base [base-path-auth base-regex-auth]
+            allow [allow-list allow-single nil]
+            deny [deny-list deny-single nil]]
+      (let [rule (merge base allow deny)]
+        (when (or allow deny)
+          (is (= rule (validate-auth-config-rule! rule))))))))
+
+(deftest invalid-configs-fail
+  (testing "Missing keys are not valid"
+    (is (thrown-with-msg? IllegalArgumentException
+          #"An authorization rule should be specified as a map"
+          (validate-auth-config-rule! 0)))
+
+    (is (thrown-with-msg? IllegalArgumentException
+          #".* does not contain a 'path' key."
+          (validate-auth-config-rule! {:type "path"})))
+
+    (is (thrown-with-msg? IllegalArgumentException
+          #".* does not contain a 'type' key."
+          (validate-auth-config-rule! {:path "/path"})))
+
+    (is (thrown-with-msg? IllegalArgumentException
+          #".* must contain either a 'deny' or 'allow' rule."
+          (validate-auth-config-rule! {:path "/foo/bar/baz"
+                                       :type "path"})))
+
+    (is (thrown-with-msg? IllegalArgumentException
+          #".* It should be set to either 'path' or 'regex'."
+          (validate-auth-config-rule! {:path "/who/cares"
+                                       :type "not-a-type"
+                                       :allow "hillbillies"})))
+
+    (is (thrown-with-msg? IllegalArgumentException
+          #".* It should be a string."
+          (validate-auth-config-rule! {:path 42
+                                       :type "path"
+                                       :allow "hicks"})))
+
+    (is (thrown-with-msg? IllegalArgumentException
+          #".* is not a string."
+          (validate-auth-config-rule! {:path "/"
+                                       :type "path"
+                                       :allow 23})))
+
+    (is (thrown-with-msg? IllegalArgumentException
+          #".* contains one or more names that are not strings."
+          (validate-auth-config-rule! {:path "/"
+                                       :type "path"
+                                       :deny ["one.anem" 23]})))
+
+    (is (thrown-with-msg? IllegalArgumentException
+          #".* Dangling meta character '\*' near index 0[.\s]*"
+          (validate-auth-config-rule! {:path  "*."
+                                       :type  "regex"
+                                       :allow "somewhere"})))))
+
+(deftest transform-config-test
+  (testing "Basic rules are translated properly"
+    (let [{:keys [type path method]}
+          (transform-config-rule (merge base-path-auth allow-list))]
+      (is (= :string type))
+      (is (= (str path) (str #"/foo/bar/baz")))
+      (is (= :any method)))
+
+    (let [{:keys [type path method]}
+          (transform-config-rule (merge base-regex-auth allow-single))]
+      (is (= :regex type))
+      (is (= (str path) "(incoming|outgoing)"))
+      (is (= :any method))))
+
+
+  ;; TODO: Write tests that exercise the `transform-config-rule-to-acl` function
+  )
+
+
+
+

--- a/test/puppetlabs/trapperkeeper/services/authorization/authorization_core_test.clj
+++ b/test/puppetlabs/trapperkeeper/services/authorization/authorization_core_test.clj
@@ -12,6 +12,27 @@
 (def deny-single {:deny "bald.guy.com"})
 (def deny-list {:deny ["bald.eagle.com" "bald.bull.com"]})
 
+(def expected-acl-as-vec
+  "The expected ACL given the configuration of a base-path combined with
+   allow-single and deny-single.  The API returns a sorted-set and so
+   this is a vector to allow easy ordered comparison in the tests.
+   Pass the ACL through the vec function when asserting against this
+   definition."
+  [{:auth-type :deny
+    :length    nil
+    :pattern   ["com"
+                "guy"
+                "bald"]
+    :qualifier :exact
+    :type      :domain}
+   {:auth-type :allow
+    :length    nil
+    :pattern   ["org"
+                "domain"
+                "www"]
+    :qualifier :exact
+    :type      :domain}])
+
 (deftest valid-configs-pass
   (testing "Valid forms of a auth config pass"
     (doseq [base [base-path-auth base-regex-auth]
@@ -82,11 +103,35 @@
           (transform-config-rule (merge base-regex-auth allow-single))]
       (is (= :regex type))
       (is (= (str path) "(incoming|outgoing)"))
-      (is (= :any method))))
+      (is (= :any method)))))
 
-
-  ;; TODO: Write tests that exercise the `transform-config-rule-to-acl` function
-  )
+(deftest transform-config-rule-to-acl-test
+  (testing "Empty config rule map returns an empty ACL sorted set"
+    (is (= #{} (transform-config-rule-to-acl {}))))
+  (testing "Multiple allow and deny statements in a single path rule"
+    (let [config-rule (merge base-path-auth allow-single deny-single)
+          acl (transform-config-rule-to-acl config-rule)]
+      (is (= expected-acl-as-vec (vec acl)))))
+  (testing "Deny rules come before allow rules in the resulting ACL"
+    (let [config-rule (merge base-path-auth deny-list allow-list)
+          acl (transform-config-rule-to-acl config-rule)]
+      (is (= :deny (:auth-type (first acl))))
+      (is (= :deny (:auth-type (second acl))))
+      (is (= [:deny :deny :allow :allow] (vec (map :auth-type acl))))))
+  (testing "Allow rules with no deny are returned in order"
+    (let [config-rule (merge base-path-auth allow-list)
+          acl (transform-config-rule-to-acl config-rule)]
+      (is (= ["com" "test"] (:pattern (first acl))))
+      (is (= :inexact (:qualifier (first acl))))
+      (is (= ["org" "domain"] (:pattern (second acl))))
+      (is (= :inexact (:qualifier (second acl))))))
+  (testing "Deny rules with no allow are returned in order"
+    (let [config-rule (merge base-path-auth deny-list)
+          acl (transform-config-rule-to-acl config-rule)]
+      (is (= ["com" "bull" "bald"] (:pattern (first acl))))
+      (is (= :exact (:qualifier (first acl))))
+      (is (= ["com" "eagle" "bald"] (:pattern (second acl))))
+      (is (= :exact (:qualifier (first acl)))))))
 
 
 

--- a/test/puppetlabs/trapperkeeper/services/authorization/authorization_service_test.clj
+++ b/test/puppetlabs/trapperkeeper/services/authorization/authorization_service_test.clj
@@ -1,0 +1,1 @@
+(ns puppetlabs.trapperkeeper.services.authorization.authorization-service-test)

--- a/test/puppetlabs/trapperkeeper/services/authorization/authorization_service_test.clj
+++ b/test/puppetlabs/trapperkeeper/services/authorization/authorization_service_test.clj
@@ -20,11 +20,12 @@
 
 ; A simple service using authorization via ring middleware
 (defservice
-  echo-reverse-service EchoReverseService [[:AuthorizationService wrap-handler]]
+  echo-reverse-service EchoReverseService
+  [[:AuthorizationService wrap-with-authorization-check]]
   (echo-reverse
     [this msg]
     (let [handler (fn [req] (response (str msg (str/reverse (:body req)))))]
-      (wrap-handler handler))))
+      (wrap-with-authorization-check handler))))
 
 (def minimal-config
   "Minimal config required to bootstrap AuthorizationService with

--- a/test/puppetlabs/trapperkeeper/services/authorization/authorization_service_test.clj
+++ b/test/puppetlabs/trapperkeeper/services/authorization/authorization_service_test.clj
@@ -1,1 +1,58 @@
-(ns puppetlabs.trapperkeeper.services.authorization.authorization-service-test)
+(ns puppetlabs.trapperkeeper.services.authorization.authorization-service-test
+  (:require
+    [clojure.test :refer :all]
+    [clojure.string :as str]
+    [puppetlabs.trapperkeeper.app :refer [get-service]]
+    [puppetlabs.trapperkeeper.services :refer [defservice]]
+    [puppetlabs.trapperkeeper.services.authorization.authorization-service :refer [authorization-service]]
+    [puppetlabs.trapperkeeper.testutils.bootstrap :refer [with-app-with-config]]
+    [puppetlabs.trapperkeeper.testutils.logging :refer [with-test-logging]]
+    [ring.util.response :refer [response]]
+    [schema.test :as schema-test]))
+
+(use-fixtures :once schema-test/validate-schemas)
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; Utilities
+
+(defprotocol EchoReverseService
+  (echo-reverse [this msg]))
+
+; A simple service using authorization via ring middleware
+(defservice
+  echo-reverse-service EchoReverseService [[:AuthorizationService wrap-handler]]
+  (echo-reverse
+    [this msg]
+    (let [handler (fn [req] (response (str msg (str/reverse (:body req)))))]
+      (wrap-handler handler))))
+
+(def minimal-config
+  "Minimal config required to bootstrap AuthorizationService with
+  EchoReverseService as a dependant consumer.
+
+  An empty list representing no rules with an expected behavior of
+  default-deny originating in the authorization library itself."
+  {:authorization {:rules []}})
+
+(def base-request
+  "A basic request to feed into the tests"
+  {:uri "/foo/bar"
+   :request-method :get
+   :remote-addr "127.0.0.1"})
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; Tests
+
+(deftest ^:integration wrap-handler-test
+  (with-test-logging
+    (with-app-with-config
+      app
+      [echo-reverse-service authorization-service]
+      minimal-config
+      (testing "The echo-reverse service function"
+        (let [svc (get-service app :EchoReverseService)
+              echo-handler (echo-reverse svc "Prefix: ")
+              req (assoc base-request :body "Hello World!")
+              {:keys [body status]} (echo-handler req)]
+          (is (= 401 status))
+          (is (= "global deny all - no rules matched" body)))))))


### PR DESCRIPTION
NOTE:

The ticket describes implementing the protocol function to wrap the middleware.
This work remains for this ticket and I'm in the process of implementing that
now.  I'm getting the PR up for early review, however, in an effort to get this
in before the sprint ends.

---

This patch establishes the basic structure of the TK service and implements
initialization logic that does the following:
- pull in a "rules" vector from the "authorization" Trapperkeeper
  configuration section (:ConfigService get-config)
- do any initial structural validation that seems appropriate
- transform that structure into the working
  puppetlabs.trapperkeeper.authorization.rules.Rules vector that
  "trapperkeeper-authorization" will need to use for its allowed? checks
  later on
- store the Rules vector into the service context

(TK-258) Add transform-config-rule-to-acl function

Without this patch there is no way to transform a rule expressed as
trapperkeeper configuration into an Access Control List data structure.
This is a problem because we need to feed ACL objects into the
authorization library.  This patch addresses the problem by implementing
the transformation function.  The implementation starts with an empty acl,
which itself is a sorted set, and then builds up the ACL by adding named
rules for each allow and deny entry in the TK configuration.
