### PR TITLE
(MAINT) Simplify SSL certs and cleanup project.clj

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,9 +1,10 @@
+(def ks-version "1.0.0")
 (def tk-version "1.1.1")
 (def tk-jetty-version "1.3.1")
 (def tk-authz-version "0.0.1")
 
 (defproject puppetlabs/trapperkeeper-authorization tk-authz-version
-  :description "TrapperKeeper authorization system"
+  :description "Trapperkeeper authorization system"
   :url "http://github.com/puppetlabs/trapperkeeper-authorization"
   :license {:name "Apache License, Version 2.0"
             :url "http://www.apache.org/licenses/LICENSE-2.0.html"}
@@ -14,16 +15,18 @@
   :pedantic? :abort
 
   :dependencies [[org.clojure/clojure "1.6.0"]
-                 [puppetlabs/trapperkeeper ~tk-version]
-                 [puppetlabs/trapperkeeper-webserver-jetty9 ~tk-jetty-version]
-                 ;; Logging
                  [org.clojure/tools.logging "0.2.6"]
-                 ;; Filesystem utilities
-                 [me.raynes/fs "1.4.5"]
                  [org.clojure/tools.cli "0.3.0"]
+                 [me.raynes/fs "1.4.5"]
                  [prismatic/schema "0.4.0"]
                  [inet.data "0.5.5"]
-                 [clj-time "0.7.0"]
+
+                 ;; begin version conflict resolution dependencies
+                 [clj-time "0.10.0"]
+                 ;; end version conflict resolution dependencies
+
+                 [puppetlabs/kitchensink ~ks-version]
+                 [puppetlabs/trapperkeeper ~tk-version]
                  [puppetlabs/typesafe-config "0.1.4"]
                  [puppetlabs/ssl-utils "0.8.1"]]
 
@@ -34,8 +37,8 @@
   :classifiers [["test" :testutils]]
 
   :profiles {:dev {:dependencies [[puppetlabs/trapperkeeper ~tk-version :classifier "test" :scope "test"]
-                                  [puppetlabs/trapperkeeper-webserver-jetty9 ~tk-jetty-version :classifier "test"]
-                                  [puppetlabs/kitchensink "1.0.0" :classifier "test"]]}
+                                  [puppetlabs/kitchensink ~ks-version :classifier "test"]
+                                  [ring/ring-core "1.4.0" :scope "test"]]}
              :testutils {:source-paths ^:replace ["test"]}}
 
   ;; this plugin is used by jenkins jobs to interrogate the project version

--- a/test/puppetlabs/trapperkeeper/authorization/testutils.clj
+++ b/test/puppetlabs/trapperkeeper/authorization/testutils.clj
@@ -1,36 +1,15 @@
 (ns puppetlabs.trapperkeeper.authorization.testutils
-  (:require [puppetlabs.ssl-utils.core :as ssl])
-  (:import (org.joda.time DateTime Period)))
+  (:require [puppetlabs.ssl-utils.simple :as ssl]))
 
 (defn request
   "Builds a ring request"
   [path method certificate ip]
   {:uri path :request-method method :remote-addr ip :ssl-client-cert certificate})
 
-;; Extracted from ssl-utils test
-
-(defn- generate-not-before-date []
-  (-> (DateTime/now)
-      (.minus (Period/days 1))
-      (.toDate)))
-
-(defn- generate-not-after-date []
-  (-> (DateTime/now)
-      (.plus (Period/years 5))
-      (.toDate)))
-
 (defn create-certificate
   [cn]
-  (let [subject (ssl/cn cn)
-        key-pair (ssl/generate-key-pair 512)
-        subj-pub (ssl/get-public-key key-pair)
-        issuer (ssl/cn "my ca")
-        issuer-key-pair (ssl/generate-key-pair 512)
-        issuer-priv (ssl/get-private-key issuer-key-pair)
-        not-before (generate-not-before-date)
-        not-after (generate-not-after-date)
-        serial 42]
-    (ssl/sign-certificate issuer issuer-priv serial not-before not-after subject subj-pub)))
+  (let [cacert (ssl/gen-self-signed-cert "my ca" 41 {:keylength 512})]
+    (:cert (ssl/gen-cert cn cacert 42 {:keylength 512}))))
 
 (def test-domain-cert (create-certificate "test.domain.org"))
 (def test-other-cert (create-certificate "www.other.org"))


### PR DESCRIPTION
This commit updates testutils to use the new jvm-ssl-utils 'simple' API
for generating certificates.

---

This commit does a few cleanup things:
- Add new 'conflict resolution dependencies' section with clj-time
- Add clj-kitchensink as a proper dependency since it's used directly in
  production code
- Replace the tk-jetty9 dependency with ring-core, as the tk-jetty9
  dependency was only used to transitively access ring.util.response in
  tests
