### PR TITLE
(TK-275) Add :match-request to config rule

### DIFF
--- a/src/puppetlabs/trapperkeeper/authorization/rules.clj
+++ b/src/puppetlabs/trapperkeeper/authorization/rules.clj
@@ -12,9 +12,9 @@
 (def Rule
   "An ACL rule, with no less than a matching path, possibly a method list and an acl"
   {
-   :type (schema/enum :string :regex)
+   :type Type
    :path Pattern
-   :method (schema/enum :get :post :put :delete :head :any)
+   :method Method
    :acl acl/ACL
    (schema/optional-key :query-params) {schema/Str #{schema/Str}}
    (schema/optional-key :file) schema/Str
@@ -78,7 +78,7 @@
   ([path :- schema/Str]
     (new-path-rule path :any))
   ([path :- schema/Str
-   method :- Method]
+    method :- Method]
     (new-rule :string (path->pattern path) method)))
 
 (schema/defn new-regex-rule :- Rule

--- a/test/puppetlabs/trapperkeeper/services/authorization/authorization_service_test.clj
+++ b/test/puppetlabs/trapperkeeper/services/authorization/authorization_service_test.clj
@@ -39,15 +39,17 @@
 
 (def basic-rules
   "Basic config exercising the use case of restricting a catalog to a node"
-  [{:path "/puppet/v3/catalog/([^/]+)"
-    :type "regex"
-    :method :get
+  [{:match-request
+    {:path "/puppet/v3/catalog/([^/]+)"
+     :type "regex"
+     :method :get}
     :allow "$1"}])
 
 (def default-rules
   "A representative example list of rules intended to model the defaults"
-  [{:path "/puppet/v3/environments"
-    :type "path"
+  [{:match-request
+    {:path "/puppet/v3/environments"
+     :type "path"}
     :allow "*"}])
 
 (def catalog-request-nocert
@@ -106,11 +108,12 @@
 
 (deftest ^:integration query-params-test
   (let [app (build-ring-handler
-             [{:path "/puppet/v3/environments"
-               :type "path"
-               :allow "*"
-               :query-params {"environment" ["test" "prod"]
-                              "foo" ["bar"]}}])
+             [{:match-request
+               {:path "/puppet/v3/environments"
+                :type "path"
+                :query-params {"environment" ["test" "prod"]
+                               "foo" ["bar"]}}
+               :allow "*"}])
         req (assoc base-request
                    :uri "/puppet/v3/environments"
                    :body "Query Param Test")


### PR DESCRIPTION
This commit adds a new section to the rule specified in the
configuration file called :match-request that now contains the :type,
:path, :method, and :query-params fields.

Note this :match-request section only exists in the configuration file.
In-memory Rules are not changed; the keys will be at the top-level.
