### PR TITLE
(TK-277) Avoid slurping request body

### DIFF
--- a/src/puppetlabs/trapperkeeper/services/authorization/authorization_service.clj
+++ b/src/puppetlabs/trapperkeeper/services/authorization/authorization_service.clj
@@ -1,10 +1,9 @@
 (ns puppetlabs.trapperkeeper.services.authorization.authorization-service
   (:require [puppetlabs.trapperkeeper.authorization.ring-middleware :refer
-             [wrap-authorization-check]]
+             [wrap-authorization-check wrap-query-params]]
             [puppetlabs.trapperkeeper.core :refer [defservice]]
             [puppetlabs.trapperkeeper.services.authorization.authorization-core :refer :all]
-            [puppetlabs.trapperkeeper.services :refer [service-context]]
-            [ring.middleware.params :as ring]))
+            [puppetlabs.trapperkeeper.services :refer [service-context]]))
 
 (defprotocol AuthorizationService
   (wrap-with-authorization-check [this handler]))
@@ -23,4 +22,4 @@
     (let [rules (get-in (service-context this) [:rules])]
       (-> handler
           (wrap-authorization-check rules)
-          ring/wrap-params))))
+          wrap-query-params))))


### PR DESCRIPTION
This commit changes tk-authz to use a custom middleware function which
parses the request query string into request parameters without, in the
case of a urlencoded form post, slurping the request body into a string
which is then not available to any downstream consumers of the Ring
request map.  The previous commit would slurp the request body in this
case because this is the default behavior performed by Ring's
`wrap-params` middleware function, which tk-authz was previously using.
