### PR TITLE
(TK-279) Log message before returning denial

### DIFF
--- a/test/puppetlabs/trapperkeeper/services/authorization/authorization_service_test.clj
+++ b/test/puppetlabs/trapperkeeper/services/authorization/authorization_service_test.clj
@@ -211,7 +211,8 @@
         (is (= status 403))
         (is (= body (str "Forbidden request: (127.0.0.1) "
                          "access to /puppet/v3/catalog/localhost "
-                         "(method :get) (authentic: false)"))))))
+                         "(method :get) (authentic: false) "
+                         "denied by rule 'puppetlabs catalog'."))))))
   (testing "certificate_request"
     (let [app (build-ring-handler default-rules)]
       (let [req (request "/puppet-ca/v1/certificate_request/ca"


### PR DESCRIPTION
This commit simply adds a call to log/error to print the denial message
before returning it as an HTTP response.
