### PR TITLE
(MAINT) Query params as keywords

### DIFF
--- a/src/puppetlabs/trapperkeeper/authorization/rules.clj
+++ b/src/puppetlabs/trapperkeeper/authorization/rules.clj
@@ -18,7 +18,7 @@
    :sort-order schema/Int
    :name schema/Str
    (schema/optional-key :allow-unauthenticated) schema/Bool
-   (schema/optional-key :query-params) {schema/Str #{schema/Str}}
+   (schema/optional-key :query-params) {schema/Keyword #{schema/Str}}
    (schema/optional-key :file) schema/Str
    (schema/optional-key :line) schema/Int})
 
@@ -68,10 +68,10 @@
    appended to existing values.
 
    The query parameters are in a map under the `:query-params` section of the
-   rule. Keys in the map are strings corresponding to the query parameters to
+   rule. Keys in the map are keywords corresponding to the query parameters to
    match, and the values are sets of strings of acceptable values."
   [rule :- Rule
-   param :- schema/Str
+   param :- schema/Keyword
    value :- (schema/either schema/Str [schema/Str])]
   (update-in rule [:query-params param] (comp set into) (flatten [value])))
 
@@ -122,7 +122,7 @@
   (every? some?
           (for [k (keys rule-params)]
             (some (get rule-params k)
-                  (flatten [(get request-params k)])))))
+                  (flatten [(get request-params (name k))])))))
 
 (schema/defn match? :- RuleMatch
   "Returns the rule if it matches the request URI, and also any capture groups of the Rule pattern if there are."

--- a/src/puppetlabs/trapperkeeper/services/authorization/authorization_core.clj
+++ b/src/puppetlabs/trapperkeeper/services/authorization/authorization_core.clj
@@ -179,7 +179,7 @@
       (throw (IllegalArgumentException. "Rule query-params must be a map.")))
     (doseq [param (keys query-params)
             :let [value (get query-params param)]]
-      (when-not (string? param)
+      (when-not (keyword? param)
         (throw (IllegalArgumentException.
                 (str "The query-param '" param "' in the rule specified as "
                      (pprint-rule rule) " is invalid. It should be a string."))))

--- a/test/puppetlabs/trapperkeeper/authorization/rules_test.clj
+++ b/test/puppetlabs/trapperkeeper/authorization/rules_test.clj
@@ -64,11 +64,11 @@
 
 (deftest test-matching-query-parameters
   (let [rule (testutils/new-rule :path "/path/to/resource" :any)
-        foo-rule (rules/query-param rule "environment" "foo")
-        foo-bar-rule (rules/query-param rule "environment" ["foo" "bar"])
+        foo-rule (rules/query-param rule :environment "foo")
+        foo-bar-rule (rules/query-param rule :environment ["foo" "bar"])
         multiples-rule (-> rule
-                           (rules/query-param "beatles" ["lennon" "starr"])
-                           (rules/query-param "monkees" "davy"))]
+                           (rules/query-param :beatles ["lennon" "starr"])
+                           (rules/query-param :monkees "davy"))]
 
     (testing "request matches rule"
       (are [rule params] (= rule (->> params

--- a/test/puppetlabs/trapperkeeper/services/authorization/authorization_core_test.clj
+++ b/test/puppetlabs/trapperkeeper/services/authorization/authorization_core_test.clj
@@ -16,10 +16,8 @@
 (def allow-list {:allow ["*.domain.org" "*.test.com"]})
 (def deny-single {:deny "bald.guy.com"})
 (def deny-list {:deny ["bald.eagle.com" "bald.bull.com"]})
-(def single-query-param {:match-request
-                         {:query-params {"environment" "production"}}})
-(def multi-query-param {:match-request
-                        {:query-params {"env" ["prod" "staging"]}}})
+(def single-query-param {:match-request {:query-params {:environment "production"}}})
+(def multi-query-param {:match-request {:query-params {:env ["prod" "staging"]}}})
 (def allow-unauthenticated {:allow-unauthenticated true})
 (def method-get {:match-request {:method "get"}})
 (def method-put {:match-request {:method "put"}})
@@ -167,21 +165,21 @@
          #".* It should be a string."
          (validate-auth-config-rule!
           (assoc-in testrule [:match-request :query-params]
-                    {:notastring []}))))
+                    {0 []}))))
 
     (is (thrown-with-msg?
          IllegalArgumentException
          #".* It should be a string or list of strings."
          (validate-auth-config-rule!
           (assoc-in testrule [:match-request :query-params]
-                    {"env" :notastringorlist}))))
+                    {:env :notastringorlist}))))
 
     (is (thrown-with-msg?
          IllegalArgumentException
          #".* contains one or more values that are not strings."
          (validate-auth-config-rule!
           (assoc-in testrule [:match-request :query-params]
-                    {"env" [:notastring]}))))
+                    {:env [:notastring]}))))
 
     (is (thrown-with-msg?
          IllegalArgumentException
@@ -212,12 +210,12 @@
         (is (= (str path) "^\\Q/foo/bar/baz\\E")))
       (is (= :put method))))
   (testing "Given a rule config with query parameters"
-    (is (= {"env" #{"prod" "staging"}}
+    (is (= {:env #{"prod" "staging"}}
            (-> (merge-with merge multi-query-param base-path-auth)
                config->rule
                :query-params)))
     (testing "single values are converted to sets"
-      (is (= {"environment" #{"production"}}
+      (is (= {:environment #{"production"}}
              (-> (merge-with merge single-query-param base-path-auth)
                  config->rule
                  :query-params)))))

--- a/test/puppetlabs/trapperkeeper/services/authorization/authorization_service_test.clj
+++ b/test/puppetlabs/trapperkeeper/services/authorization/authorization_service_test.clj
@@ -233,8 +233,8 @@
              [{:match-request
                {:path "/puppet/v3/environments"
                 :type "path"
-                :query-params {"environment" ["test" "prod"]
-                               "foo" ["bar"]}}
+                :query-params {:environment ["test" "prod"]
+                               :foo ["bar"]}}
                :allow "*"
                :sort-order 100
                :name "environments"}])


### PR DESCRIPTION
This commit fixes the mis-typing of query parameters keys from strings
to keywords. HOCON will parse the auth.conf file and return keywords,
not strings, for these query parameter fields.
