### PR TITLE
(TK-282) Add `allow-header-cert-info` support

### DIFF
--- a/doc/authorization-config.md
+++ b/doc/authorization-config.md
@@ -45,15 +45,13 @@ should use.  The only supported value is "1".
 
 ### `allow-header-cert-info`
 
-*(TBD, [SERVER-763](https://tickets.puppetlabs.com/browse/SERVER-763))*
-
 Optional.  Controls how the authenticated user "name" is derived for a 
 request being authorized.  Default value for the setting is `false`.
 
 For a value of `false`, the authenticated "name" for the request is derived 
 from the Common Name (CN) attribute within an X.509 certificate's Subject 
 Distinguished Name (DN).  The `wrap-with-authorization-check` middleware 
-tries to get the request's X.509 certificate from the `:ssl-client-cert` key 
+tries to get the request's X.509 certificate from the `ssl-client-cert` key
 in the Ring request map.  If the certificate cannot be found, e.g., if the 
 request was made over plaintext or was made over SSL/TLS but no certificate 
 was provided by the client, or the CN is not present in the certificate, the
@@ -62,13 +60,38 @@ request is considered "unauthenticated".
 For a value of `true`, the authenticated "name" for the request is derived from
 evaluating the values set for the `X-Client-DN` and `X-Client-Verify` HTTP 
 headers in the request.  The value for an `X-Client-DN` HTTP header should be
-in the form of a Subject DN from an X.509 certificate.  If the 
-`X-Client-Verify` HTTP header for the request has a value of `SUCCESS`, the 
-authenticated "name" for the request is extracted from the CN attribute in 
-the `X-Client-DN` value, if available.  If the `X-Client-Verify` HTTP header 
-is not present or does not have a value of `SUCCESS` and/or the CN cannot be 
-extracted from the `X-Client-DN` value, the request is considered
-"unauthenticated".
+in the form of a Subject DN from an X.509 certificate (e.g., `CN=myname`).  A
+value of `SUCCESS` for the `X-Client-Verify` HTTP header indicates that the
+request was validated successfully.  If the `X-Client-Verify` HTTP header is not
+present or does not have a value of `SUCCESS` and/or the CN cannot be extracted
+from the `X-Client-DN` value, the request is considered "unauthenticated".
+
+The `X-Client-DN` will attempt to be parsed first as an DN per
+[RFC 2253](https://www.ietf.org/rfc/rfc2253.txt).  For example:
+ 
+~~~~
+O=tester\, inc., CN=tester.test.org
+~~~~
+
+If the DN is not found to conform to the RFC 2253 format, the `X-Client-DN`
+will be parsed per the OpenSSL
+[compat](https://www.openssl.org/docs/manmaster/apps/x509.html) DN format, where
+attribute key/value pairs are delimited by solidus, `/`, characters:
+
+~~~~
+/O=tester, inc./CN=tester.test.org
+~~~~
+
+If a CN value cannot be derived via either parsing approach, the handler returns
+an HTTP 400/Bad Request response.
+
+> **Note:** The "compat" OpenSSL DN format does not provide a way to escape
+special characters in the DN.  If a solidus character were intended to be
+part of the value of an attribute, an unintended CN value could be derived.
+For example, the CN extracted from a DN of `/CN=tester/ inc.` is interpreted as
+`tester` rather than as `tester/ inc.`.  The RFC 2253 format has a specified
+approach for escaping special characters and is, therefore, preferred for
+expressing DN values, where possible.
 
 An "unauthenticated" request can only be "allowed" when the first matching 
 rule has an `allow-unauthenticated` setting with a value of `true`.  If 
@@ -79,10 +102,6 @@ request, the request is "denied" - in which case the handler returns an HTTP
 settings for the first rule which matches the request.  See the documentation
 for the [`allow`](#allow) and [`deny`](#deny) settings for more information.
 
-Until the work is completed for SERVER-763, trapperkeeper-authorization will
-only try to derive the authenticated "name" for a request from the CN in the
-X.509 certificate.
-
 ### `rules`
 
 Required.  An array in which each of the elements is a map of settings 
@@ -92,13 +111,13 @@ pertaining to a rule.  Here is an example of an array with two rules:
 rules: [
         {
             match-request: {
-                path: "/my_path"
-                type: path
+                path: "^/my_path/([^/]+)$"
+                type: regex
                 method: get
             }
-            allow: "*"
+            allow: "$1"
             sort-order: 1
-            name: "my_path"
+            name: "user-specific my_path"
         },
         {
             match-request: {

--- a/doc/authorization-config.md
+++ b/doc/authorization-config.md
@@ -66,7 +66,7 @@ request was validated successfully.  If the `X-Client-Verify` HTTP header is not
 present or does not have a value of `SUCCESS` and/or the CN cannot be extracted
 from the `X-Client-DN` value, the request is considered "unauthenticated".
 
-The `X-Client-DN` will attempt to be parsed first as an DN per
+The `X-Client-DN` will attempt to be parsed first as a DN per
 [RFC 2253](https://www.ietf.org/rfc/rfc2253.txt).  For example:
  
 ~~~~

--- a/src/puppetlabs/trapperkeeper/authorization/ring.clj
+++ b/src/puppetlabs/trapperkeeper/authorization/ring.clj
@@ -2,18 +2,6 @@
   (:require [schema.core :as schema])
   (:import (java.security.cert X509Certificate)))
 
-(def cert-key
-  "The nested key where the client certificate for the request is stored"
-  [:authorization :certificate])
-
-(def is-authentic-key
-  "The nested key where authenticity information is stored."
-  [:authorization :authentic?])
-
-(def name-key
-  "The nested key where the identifying name of the request is stored."
-  [:authorization :name])
-
 ;; schema
 
 (def RequestMethod (schema/enum :get :post :put :delete :head :options))
@@ -27,3 +15,36 @@
    schema/Keyword schema/Any})
 
 ;; Functions
+
+(schema/defn get-authorized-authentic? :- schema/Bool
+  "Get whether the authorized client is considered authentic or not."
+  [request :- Request]
+  (get-in request [:authorization :authentic?]))
+
+(schema/defn set-authorized-authentic? :- Request
+  "Set whether the authorized client is considered authentic or not."
+  [request :- Request
+   authentic? :- schema/Bool]
+  (assoc-in request [:authorization :authentic?] authentic?))
+
+(schema/defn get-authorized-certificate :- (schema/maybe X509Certificate)
+  "Get the certificate of the authorized client."
+  [request :- Request]
+  (get-in request [:authorization :certificate]))
+
+(schema/defn set-authorized-certificate :- Request
+  "Get the certificate of the authorized client."
+  [request :- Request
+   certificate :- (schema/maybe X509Certificate)]
+  (assoc-in request [:authorization :certificate] certificate))
+
+(schema/defn get-authorized-name :- schema/Str
+  "Get the authorized client name from the request."
+  [request :- Request]
+  (get-in request [:authorization :name] ""))
+
+(schema/defn set-authorized-name :- Request
+  "Set the authorized client name onto the request."
+  [request :- Request
+   name :- (schema/maybe schema/Str)]
+  (assoc-in request [:authorization :name] (str name)))

--- a/src/puppetlabs/trapperkeeper/authorization/ring.clj
+++ b/src/puppetlabs/trapperkeeper/authorization/ring.clj
@@ -2,6 +2,10 @@
   (:require [schema.core :as schema])
   (:import (java.security.cert X509Certificate)))
 
+(def cert-key
+  "The nested key where the client certificate for the request is stored"
+  [:authorization :certificate])
+
 (def is-authentic-key
   "The nested key where authenticity information is stored."
   [:authorization :authentic?])

--- a/src/puppetlabs/trapperkeeper/authorization/ring.clj
+++ b/src/puppetlabs/trapperkeeper/authorization/ring.clj
@@ -16,7 +16,7 @@
 
 ;; Functions
 
-(schema/defn get-authorized-authentic? :- schema/Bool
+(schema/defn authorized-authentic? :- schema/Bool
   "Get whether the authorized client is considered authentic or not."
   [request :- Request]
   (get-in request [:authorization :authentic?]))
@@ -27,7 +27,7 @@
    authentic? :- schema/Bool]
   (assoc-in request [:authorization :authentic?] authentic?))
 
-(schema/defn get-authorized-certificate :- (schema/maybe X509Certificate)
+(schema/defn authorized-certificate :- (schema/maybe X509Certificate)
   "Get the certificate of the authorized client."
   [request :- Request]
   (get-in request [:authorization :certificate]))
@@ -38,7 +38,7 @@
    certificate :- (schema/maybe X509Certificate)]
   (assoc-in request [:authorization :certificate] certificate))
 
-(schema/defn get-authorized-name :- schema/Str
+(schema/defn authorized-name :- schema/Str
   "Get the authorized client name from the request."
   [request :- Request]
   (get-in request [:authorization :name] ""))

--- a/src/puppetlabs/trapperkeeper/authorization/ring_middleware.clj
+++ b/src/puppetlabs/trapperkeeper/authorization/ring_middleware.clj
@@ -1,47 +1,260 @@
 (ns puppetlabs.trapperkeeper.authorization.ring-middleware
   (:require [schema.core :as schema]
             [ring.middleware.params :as ring-params]
+            [ring.util.codec :as ring-codec]
             [ring.util.request :as ring-request]
+            [ring.util.response :as ring-response]
+            [slingshot.slingshot :as sling]
             [puppetlabs.trapperkeeper.authorization.rules :as rules]
             [puppetlabs.trapperkeeper.authorization.ring :as ring]
-            [puppetlabs.ssl-utils.core :as ssl-utils])
-  (:import  (clojure.lang IFn)))
+            [puppetlabs.ssl-utils.core :as ssl-utils]
+            [clojure.tools.logging :as log]
+            [clojure.string :as str])
+  (:import (clojure.lang IFn)
+           (java.security.cert X509Certificate)
+           (java.io StringReader)))
 
-(schema/defn request->name :- (schema/maybe schema/Str)
-  "Return the identifying name of the request or nil"
-  [request :- ring/Request]
-  ; TODO SERVER-763 Support the name from the X headers
-  (if-let [certificate (:ssl-client-cert request)]
-    (ssl-utils/get-cn-from-x509-certificate certificate)))
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; Private
+
+(def header-cert-name
+  "Name of the HTTP header through which a client certificate can be passed
+  for a request."
+  "x-client-cert")
+
+(def header-dn-name
+  "Name of the HTTP header through which a client dn can be passed
+  for a request."
+  "x-client-dn")
+
+(def header-client-verify-name
+  "Name of the HTTP header through which a client verify can be passed
+  for a request."
+  "x-client-verify")
+
+(defn warn-if-header-value-non-nil
+  "Log a warning message if the supplied header-val is non-empty."
+  [header-name header-val]
+  (if header-val
+    (log/warn "The HTTP header" header-name "was specified with" header-val
+              "but the allow-header-cert-info was either not set, or was set"
+              "to false.  This header will be ignored.")))
+
+(defn throw-bad-request!
+  "Throw a ::bad-request type slingshot error with the supplied message."
+  [message]
+  (sling/throw+ {:type ::bad-request :message message}))
+
+(defn legacy-openssl-dn->cn
+  "Attempt to parse the supplied 'dn' string as a legacy OpenSSL-style DN,
+  where the attributes in the DN are delimited by solidus characters, and
+  return back the value for a CN attribute found within it.  For example,
+  if the supplied 'dn' were '/O=myorg/CN=myname', then the value returned
+  would be 'myname'.  If a value for the CN attribute cannot be found, either
+  because the original format of the 'dn' wasn't in the legacy OpenSSL-style
+  or no CN attribute was found within the 'dn', this function would return
+  nil."
+  [dn]
+  (when-not (nil? dn)
+    (some #(if (= "CN" (first %1)) (second %1))
+          (map #(str/split %1 #"=" 2) (str/split dn #"/")))))
+
+(defn warn-for-empty-common-name
+  "Log a warning message if the supplied common-name is empty (nil or empty
+  string."
+  ([common-name empty-message-format empty-message-arg1]
+   (warn-for-empty-common-name common-name
+                               empty-message-format
+                               empty-message-arg1
+                               ""))
+  ([common-name empty-message-format empty-message-arg1 empty-message-arg2]
+   (if (empty? common-name)
+     (log/warnf (str empty-message-format
+                     "  Treating client as 'unauthenticated'.")
+                empty-message-arg1
+                empty-message-arg2))
+   common-name))
+
+(defn request->name*
+  "Pull the common name from the request, considering whether or not the
+  name should be pulled from headers or an SSL certificate (per the
+  allow-header-cert-info setting).  header-dn-val is the value of the
+  DN in an HTTP header for the request, if available."
+  [request header-dn-val allow-header-cert-info]
+  (cond
+    (not allow-header-cert-info)
+      (do
+        (warn-if-header-value-non-nil header-dn-name header-dn-val)
+        (if-let [certificate (:ssl-client-cert request)]
+          (warn-for-empty-common-name
+           (ssl-utils/get-cn-from-x509-certificate certificate)
+           "CN could not be found in certificate DN: %s."
+           (-> certificate (.getSubjectDN) (.getName)))))
+    (empty? header-dn-val)
+      nil
+    (ssl-utils/valid-x500-name? header-dn-val)
+      (warn-for-empty-common-name (ssl-utils/x500-name->CN header-dn-val)
+                                  (str "CN could not be found in RFC 2253 DN "
+                                       "provided by HTTP header '%s': %s.")
+                                  header-dn-name header-dn-val)
+    :else
+      (warn-for-empty-common-name (legacy-openssl-dn->cn header-dn-val)
+                                  (str "CN could not be found in DN provided "
+                                       "by HTTP header '%s': %s.")
+                                  header-dn-name header-dn-val)))
+
+(defn request->name
+  "Pull the common name from the request, considering whether or not the
+  name should be pulled from headers or an SSL certificate (per the
+  allow-header-cert-info setting)."
+  [request allow-header-cert-info]
+  (request->name* request
+                  (get-in request [:headers header-dn-name])
+                  allow-header-cert-info))
+
+(defn verified?
+  "Determine if the user's identity has been 'verified'.  When
+  'allow-header-cert-info' is set to 'true', the user's identity is assumed
+  to be verified externally and, so, whatever the 'x-client-verify' header
+  value is for the request is assumed to be the result of that verification.
+  'SUCCESS' is the only value for a successful verification in that case;
+  anything else is considered to be 'not verified'.  When
+  'allow-header-cert-info' is set to 'false', the user's identity (or lack
+  thereof) is assumed to have been verified by the server in which this
+  code is running, in which case a value of 'true' is always returned"
+  [request name allow-header-cert-info]
+  (let [header-client-verify-val (get-in request
+                                         [:headers header-client-verify-name])]
+    (cond
+      (not allow-header-cert-info)
+        (do
+          (warn-if-header-value-non-nil header-client-verify-name
+                                        header-client-verify-val)
+          true)
+      (= header-client-verify-val "SUCCESS") true
+      :else
+        (do
+          (if (not (empty? name))
+            (log/errorf "Client with CN '%s' was not verified by '%s' header: '%s'"
+                        name
+                        header-client-verify-name
+                        header-client-verify-val))
+          false))))
+
+(defn header-cert->pem
+  "URL decode the header cert value into a PEM string."
+  [header-cert]
+  (try
+    (ring-codec/url-decode header-cert)
+    (catch Exception e
+      (throw-bad-request!
+       (str "Unable to URL decode the "
+            header-cert-name
+            " header: "
+            (.getMessage e))))))
+
+(defn pem->certs
+  "Convert a pem string into certificate objects."
+  [pem]
+  (with-open [reader (StringReader. pem)]
+    (try
+      (ssl-utils/pem->certs reader)
+      (catch Exception e
+        (throw-bad-request!
+         (str "Unable to parse "
+              header-cert-name
+              " into certificate: "
+              (.getMessage e)))))))
+
+(defn header->cert
+  "Return an X509Certificate or nil from a string encoded for transmission
+  in an HTTP header."
+  [header-cert-val]
+  (if header-cert-val
+    (let [pem        (header-cert->pem header-cert-val)
+          certs      (pem->certs pem)
+          cert-count (count certs)]
+      (condp = cert-count
+        0 (throw-bad-request!
+           (str "No certs found in PEM read from " header-cert-name))
+        1 (first certs)
+        (throw-bad-request!
+         (str "Only 1 PEM should be supplied for "
+              header-cert-name
+              " but "
+              cert-count
+              " found"))))))
+
+(schema/defn request->cert :- (schema/maybe X509Certificate)
+  "Pull the client certificate from the request.  Response includes the
+  certificate as a java.security.cert.X509Certificate object or, if none
+  can be found, nil.  allow-header-cert-info determines whether to try to
+  pull the certificate from an HTTP header (true) or from the certificate
+  provided during SSL session negotiation (false)."
+  [request :- ring/Request
+   allow-header-cert-info :- schema/Bool]
+  (let [header-cert-val (get-in request [:headers header-cert-name])]
+    (if allow-header-cert-info
+      (header->cert header-cert-val)
+      (do
+        (warn-if-header-value-non-nil header-cert-name header-cert-val)
+        (:ssl-client-cert request)))))
 
 (schema/defn add-authinfo :- ring/Request
   "Add authentication information to the ring request."
-  [request :- ring/Request]
-  (let [id (request->name request)]
+  [request :- ring/Request
+   allow-header-cert-info :- schema/Bool]
+  (let [name (request->name request allow-header-cert-info)]
     (->
       request
-      (assoc-in ring/name-key (str id))
-      ; TODO SERVER-763 Get authenticity from header if allow-header-cert-info
-      (assoc-in ring/is-authentic-key (if id true false)))))
+      (assoc-in ring/name-key (str name))
+      (assoc-in ring/is-authentic-key (and
+                                       (verified? request
+                                                  name
+                                                  allow-header-cert-info)
+                                       (not (empty? name))))
+      (assoc-in ring/cert-key (request->cert request
+                                             allow-header-cert-info)))))
 
-(schema/defn wrap-authorization-check :- IFn
-  "A ring middleware that checks the request is allowed by the provided rules"
-  [handler :- IFn
-   rules :- rules/Rules]
-  (fn [request]
-    (let [req (add-authinfo request)
-          name (get-in req ring/name-key "")
-          {:keys [authorized message]} (rules/allowed? rules req name)]
-      (if (true? authorized)
-        (handler req)
-        {:status 403 :body message}))))
-
-(defn- assoc-query-params
+(defn assoc-query-params
+  "Associate a `query-params` map onto the supplied request from any
+  key/value pairs embedded in the request's URL query string."
   [request]
   (let [encoding (or (ring-request/character-encoding request) "UTF-8")]
     (if (:query-params request)
       request
       (ring-params/assoc-query-params request encoding))))
+
+(defn bad-request?
+  "Determine if the supplied slingshot message is for a 'bad request'"
+  [x]
+  (when (map? x) (= (:type x) ::bad-request)))
+
+(defn output-error
+  "Convert the supplied ring request, slingshot exception, and http status
+  code into a Ring response with appropriate content."
+  [{:keys [uri]} {:keys [message]} http-status]
+  (log/errorf "Error %d on SERVER at %s: %s" http-status uri message)
+  (-> (ring-response/response message)
+      (ring-response/status http-status)
+      (ring-response/content-type "text/plain")))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; Public
+
+(schema/defn wrap-authorization-check :- IFn
+  "A ring middleware that checks the request is allowed by the provided rules"
+  [handler :- IFn
+   rules :- rules/Rules
+   allow-header-cert-info :- schema/Bool]
+  (fn [request]
+    (let [req (add-authinfo request allow-header-cert-info)
+          name (get-in req ring/name-key "")
+          {:keys [authorized message]} (rules/allowed? rules req name)]
+      (if (true? authorized)
+        (handler req)
+        (-> (ring-response/response message)
+            (ring-response/status 403))))))
 
 (schema/defn wrap-query-params :- IFn
   "A ring middleware for destructuring query params from the request. This is
@@ -49,6 +262,16 @@
    not at form params in the request body for a urlencodedform post.  tk-authz
    uses this so that it doesn't consume a request body before downstream
    middleware has a chance to access it."
-  [handler]
+  [handler :- IFn]
   (fn [request]
     (handler (assoc-query-params request))))
+
+(schema/defn wrap-with-error-handling :- IFn
+  "Middleware that wraps an authorization request with some error handling to
+   return the appropriate http status codes, etc."
+  [handler :- IFn]
+  (fn [request]
+    (sling/try+
+     (handler request)
+     (catch bad-request? e
+       (output-error request e 400)))))

--- a/src/puppetlabs/trapperkeeper/authorization/ring_middleware.clj
+++ b/src/puppetlabs/trapperkeeper/authorization/ring_middleware.clj
@@ -207,14 +207,14 @@
   (let [name (request->name request allow-header-cert-info)]
     (->
       request
-      (assoc-in ring/name-key (str name))
-      (assoc-in ring/is-authentic-key (and
+      (ring/set-authorized-name (str name))
+      (ring/set-authorized-authentic? (and
                                        (verified? request
                                                   name
                                                   allow-header-cert-info)
                                        (not (empty? name))))
-      (assoc-in ring/cert-key (request->cert request
-                                             allow-header-cert-info)))))
+      (ring/set-authorized-certificate (request->cert request
+                                                      allow-header-cert-info)))))
 
 (defn assoc-query-params
   "Associate a `query-params` map onto the supplied request from any
@@ -249,7 +249,7 @@
    allow-header-cert-info :- schema/Bool]
   (fn [request]
     (let [req (add-authinfo request allow-header-cert-info)
-          name (get-in req ring/name-key "")
+          name (ring/get-authorized-name req)
           {:keys [authorized message]} (rules/allowed? rules req name)]
       (if (true? authorized)
         (handler req)

--- a/src/puppetlabs/trapperkeeper/authorization/ring_middleware.clj
+++ b/src/puppetlabs/trapperkeeper/authorization/ring_middleware.clj
@@ -249,7 +249,7 @@
    allow-header-cert-info :- schema/Bool]
   (fn [request]
     (let [req (add-authinfo request allow-header-cert-info)
-          name (ring/get-authorized-name req)
+          name (ring/authorized-name req)
           {:keys [authorized message]} (rules/allowed? rules req name)]
       (if (true? authorized)
         (handler req)

--- a/src/puppetlabs/trapperkeeper/authorization/rules.clj
+++ b/src/puppetlabs/trapperkeeper/authorization/rules.clj
@@ -140,7 +140,7 @@
   (let [ip (:remote-addr request)
         path (:uri request)
         method (:request-method request)
-        authentic? (true? (get-in request ring/is-authentic-key))]
+        authentic? (true? (ring/get-authorized-authentic? request))]
     (str "Forbidden request: " (if name (format "%s(%s)" name ip) ip)
          " access to " path " (method " method ")"
          (if-let [file (:file rule)] (str " at " file ":" (:line rule)))
@@ -181,7 +181,7 @@
   (if-let [{:keys [rule matches]} (some #(match? % request) rules)]
     (if (true? (:allow-unauthenticated rule))
       {:authorized true :message "allow-unauthenticated is true - allowed"}
-      (if (and (true? (get-in request ring/is-authentic-key)) ; authenticated?
+      (if (and (true? (ring/get-authorized-authentic? request)) ; authenticated?
             (acl/allowed? (:acl rule) name (:remote-addr request) matches))
         {:authorized true :message ""}
         (deny-request (request->description request name rule))))

--- a/src/puppetlabs/trapperkeeper/authorization/rules.clj
+++ b/src/puppetlabs/trapperkeeper/authorization/rules.clj
@@ -140,7 +140,7 @@
   (let [ip (:remote-addr request)
         path (:uri request)
         method (:request-method request)
-        authentic? (true? (ring/get-authorized-authentic? request))]
+        authentic? (true? (ring/authorized-authentic? request))]
     (str "Forbidden request: " (if name (format "%s(%s)" name ip) ip)
          " access to " path " (method " method ")"
          (if-let [file (:file rule)] (str " at " file ":" (:line rule)))
@@ -181,7 +181,7 @@
   (if-let [{:keys [rule matches]} (some #(match? % request) rules)]
     (if (true? (:allow-unauthenticated rule))
       {:authorized true :message "allow-unauthenticated is true - allowed"}
-      (if (and (true? (ring/get-authorized-authentic? request)) ; authenticated?
+      (if (and (true? (ring/authorized-authentic? request)) ; authenticated?
             (acl/allowed? (:acl rule) name (:remote-addr request) matches))
         {:authorized true :message ""}
         (deny-request (request->description request name rule))))

--- a/src/puppetlabs/trapperkeeper/services/authorization/authorization_core.clj
+++ b/src/puppetlabs/trapperkeeper/services/authorization/authorization_core.clj
@@ -3,8 +3,7 @@
             [clojure.tools.logging :as log]
             [puppetlabs.kitchensink.core :as ks]
             [schema.core :as schema]
-            [puppetlabs.trapperkeeper.authorization.rules :as rules]
-            [puppetlabs.trapperkeeper.authorization.acl :as acl])
+            [puppetlabs.trapperkeeper.authorization.rules :as rules])
   (:import (java.util.regex PatternSyntaxException)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
@@ -211,6 +210,11 @@
   (when-not (map? config)
     (throw (IllegalArgumentException.
             "The authorization service configuration is not a map.")))
+  (let [allow-header-cert-info (:allow-header-cert-info config)]
+    (when (and (not (nil? allow-header-cert-info))
+               (not (ks/boolean? allow-header-cert-info)))
+      (throw (IllegalArgumentException.
+              "allow-header-cert-info is not a boolean."))))
   (when-not (= 1 (:version config))
     (throw (IllegalArgumentException.
             (str "Unsupported or missing version in configuration file. "

--- a/test/puppetlabs/trapperkeeper/authorization/ring_middleware_test.clj
+++ b/test/puppetlabs/trapperkeeper/authorization/ring_middleware_test.clj
@@ -1,10 +1,15 @@
 (ns puppetlabs.trapperkeeper.authorization.ring-middleware-test
   (:require [clojure.test :refer :all]
+            [puppetlabs.ssl-utils.core :as ssl-utils]
             [puppetlabs.trapperkeeper.authorization.ring-middleware :as ring-middleware]
             [puppetlabs.trapperkeeper.authorization.rules :as rules]
             [puppetlabs.trapperkeeper.authorization.testutils :as testutils]
+            [puppetlabs.trapperkeeper.testutils.logging :as logutils]
             [schema.test :as schema-test]
-            [puppetlabs.trapperkeeper.testutils.logging :as logutils]))
+            [ring.util.codec :as ring-codec]
+            [ring.util.response :as ring-response]
+            [slingshot.test :refer :all])
+  (:import (java.io StringWriter)))
 
 (use-fixtures :once schema-test/validate-schemas)
 
@@ -15,46 +20,287 @@
                     (rules/allow "*.test.com")
                     (rules/deny-ip "192.168.1.0/24"))])
 
-(deftest ring-request-to-name-test
-  (testing "request to name"
+(defn wrap-x-client-dn
+  [request name]
+  (update-in request [:headers] assoc "x-client-dn" name))
+
+(defn wrap-x-client-verify
+  [request verify]
+  (update-in request [:headers] assoc "x-client-verify" verify))
+
+(defn wrap-x-client-cert
+  [request cert]
+  (update-in request [:headers] assoc "x-client-cert" cert))
+
+(defn wrap-successful-x-client-cn
+  [request name]
+  (-> request
+      (wrap-x-client-dn (str "CN=" name))
+      (wrap-x-client-verify "SUCCESS")))
+
+(deftest ring-request-to-name-allow-header-cert-info-false-tests
+  (testing (str "request to name returns good CN when ssl cert specified and "
+                "allow-header-cert-info 'false'")
     (is (= "test.domain.org"
            (ring-middleware/request->name
-            (testutils/request "/path/to/resource" :get "127.0.0.1" testutils/test-domain-cert))))))
+            (testutils/request "/path/to/resource"
+                               :get "127.0.0.1"
+                               testutils/test-domain-cert)
+            false))))
+  (testing (str "request to name nil when ssl cert not specified and "
+                "allow-header-cert-info 'false'")
+    (is (nil? (ring-middleware/request->name
+               (testutils/request "/path/to/resource"
+                                  :get "127.0.0.1"
+                                  nil)
+               false)))),
+  (testing (str "request to name returns CN from ssl and not header CN when "
+                "allow-header-cert-info 'false'")
+    (logutils/with-test-logging
+     (is (= "test.domain.org"
+            (ring-middleware/request->name
+             (-> (testutils/request "/path/to/resource"
+                                    :get "127.0.0.1"
+                                    testutils/test-domain-cert)
+                 (wrap-x-client-dn "O=tester.com, CN=tester.test.org"))
+             false))))))
+
+(deftest ring-request-to-name-allow-header-cert-info-true-tests
+  (testing (str "request to name returns good CN for RFC 2253 header DN and "
+                "allow-header-cert-info true")
+    (is (= "tester.test.org"
+           (ring-middleware/request->name
+            (-> (testutils/request)
+                (wrap-x-client-dn "O=tester\\, inc., CN=tester.test.org"))
+            true))))
+  (testing (str "request to name returns good CN for legacy OpenSSL header DN "
+                "and allow-header-cert-info true")
+    (is (= "tester.test.org"
+           (ring-middleware/request->name
+            (-> (testutils/request)
+                (wrap-x-client-dn "/O=mytester.com/CN=tester.test.org/L=whoville"))
+            true))))
+  (testing (str "request to name returns nil CN for legacy OpenSSL DN when no "
+                "CN present and allow-header-cert-info true")
+    (logutils/with-test-logging
+     (is (nil? (ring-middleware/request->name
+                (-> (testutils/request)
+                    (wrap-x-client-dn "/O=tester/L=whoville"))
+                true))))))
+
+(deftest name-verified-tests
+  (testing "verified true when not getting name from HTTP headers"
+    (is (ring-middleware/verified? (testutils/request) "localhost" false)))
+  (testing (str "verified true when getting name from HTTP headers and header "
+                "verify was successful")
+    (is (ring-middleware/verified? (-> (testutils/request)
+                                       (wrap-x-client-verify "SUCCESS"))
+                                   "localhost"
+                                   true)))
+  (testing (str "verified false when getting name from HTTP headers and header "
+                "verify was not successful")
+    (logutils/with-test-logging
+     (is (false? (ring-middleware/verified? (-> (testutils/request)
+                                                (wrap-x-client-verify "FAIL"))
+                                            "localhost"
+                                            true))))))
+
+(deftest ring-request-to-cert-with-ssl-cert
+  (testing (str "SSL certificate is extracted from the Ring request when "
+                "allow-header-cert-info is false")
+    (is (identical? testutils/test-domain-cert
+                    (ring-middleware/request->cert
+                     (-> (testutils/request)
+                         (assoc :ssl-client-cert testutils/test-domain-cert))
+                     false)))))
+
+(deftest ring-request-to-cert-from-http-header
+  (testing "Extraction of cert from HTTP header in Ring request"
+    (letfn [(cert-from-request [header-val]
+                               (ring-middleware/request->cert
+                                (-> (testutils/request)
+                                    (wrap-x-client-cert header-val))
+                                true))]
+      (testing "succeeds when cert properly URL encoded into the header"
+        (is (= "test.domain.org"
+               (ssl-utils/get-cn-from-x509-certificate
+                (cert-from-request (testutils/url-encoded-cert
+                                    testutils/test-domain-cert))))))
+      (testing "fails as expected when cert not properly URL encoded"
+        (is (thrown+? [:type :puppetlabs.trapperkeeper.authorization.ring-middleware/bad-request
+                       :message (str "Unable to URL decode the x-client-cert header: "
+                                     "For input string: \"1%\"")]
+                      (cert-from-request "%1%2"))))
+      (testing "fails as expected when URL encoded properly but base64 content malformed"
+        (is (thrown+? [:type :puppetlabs.trapperkeeper.authorization.ring-middleware/bad-request
+                       :message (str "Unable to parse x-client-cert into "
+                                     "certificate: -----END CERTIFICATE not found")]
+                      (cert-from-request
+                       "-----BEGIN%20CERTIFICATE-----%0AM"))))
+      (testing "fails when cert not in the payload"
+        (is (thrown+? [:type :puppetlabs.trapperkeeper.authorization.ring-middleware/bad-request
+                       :message "No certs found in PEM read from x-client-cert"]
+                      (cert-from-request "NOCERTSHERE"))))
+      (testing "fails when more than one cert is in the payload"
+        (let [cert-writer (StringWriter.)
+              _ (ssl-utils/cert->pem! testutils/test-domain-cert cert-writer)
+              _ (ssl-utils/cert->pem! testutils/test-domain-cert cert-writer)
+              certs-encoded (ring-codec/url-encode cert-writer)]
+          (is (thrown+? [:type :puppetlabs.trapperkeeper.authorization.ring-middleware/bad-request
+                         :message (str "Only 1 PEM should be supplied for "
+                                       "x-client-cert but 2 found")]
+                        (cert-from-request certs-encoded))))))))
 
 (def base-handler
-  (fn [request]
-    {:status 200 :body "hello"}))
+  (fn [_]
+    (ring-response/response "hello")))
 
 (defn build-ring-handler
-  [rules]
+  [rules allow-header-cert-info]
   (-> base-handler
-      (ring-middleware/wrap-authorization-check rules)))
+      (ring-middleware/wrap-authorization-check rules allow-header-cert-info)))
 
-(deftest wrap-authorization-check-test
-  (logutils/with-test-logging
-    (let [ring-handler (build-ring-handler test-rule)]
-      (testing "access allowed when cert CN is allowed"
-        (let [response (ring-handler (testutils/request "/path/to/foo" :get "127.0.0.1" testutils/test-domain-cert))]
-          (is (= 200 (:status response)))
-          (is (= "hello" (:body response)))))
-      (testing "access denied when cert CN is not in the rule"
-        (let [response (ring-handler (testutils/request "/path/to/foo" :get "127.0.0.1" testutils/test-other-cert))]
-          (is (= 403 (:status response)))
-          (is (= (str "Forbidden request: www.other.org(127.0.0.1) access to "
-                      "/path/to/foo (method :get) (authentic: true) denied by "
-                      "rule 'test rule'.")
-                 (:body response)))))
-      (testing "access denied when cert CN is explicitly denied in the rule"
-        (let [response (ring-handler (testutils/request "/path/to/foo" :get "127.0.0.1" testutils/test-denied-cert))]
-          (is (= 403 (:status response)))
-          (is (= (str "Forbidden request: bad.guy.com(127.0.0.1) access to "
-                      "/path/to/foo (method :get) (authentic: true) denied by "
-                      "rule 'test rule'.")
-                 (:body response))))))
-    (testing "Denied when deny all"
-      (let [app (build-ring-handler [(-> (testutils/new-rule :path "/")
-                                         (rules/deny "*"))])]
-        (doseq [path ["a" "/" "/hip/hop/" "/a/hippie/to/the/hippi-dee/beat"]]
-          (let [req (testutils/request path :get "127.0.0.1" testutils/test-domain-cert)
-                {status :status} (app req)]
-            (is (= status 403))))))))
+(deftest wrap-authorization-check-for-allow-header-cert-info-false-tests
+  (testing "wrap-authorization-check for allow-header-cert-info false results in"
+    (logutils/with-test-logging
+     (let [ring-handler (build-ring-handler test-rule false)]
+       (testing "access allowed when cert CN is allowed"
+         (let [response (ring-handler (testutils/request
+                                       "/path/to/foo"
+                                       :get "127.0.0.1"
+                                       testutils/test-domain-cert))]
+           (is (= 200 (:status response)))
+           (is (= "hello" (:body response)))))
+       (testing "access denied when cert CN is not in the rule"
+         (let [response (ring-handler (testutils/request
+                                       "/path/to/foo"
+                                       :get "127.0.0.1"
+                                       testutils/test-other-cert))]
+           (is (= 403 (:status response)))
+           (is (= (str "Forbidden request: www.other.org(127.0.0.1) access to "
+                       "/path/to/foo (method :get) (authentic: true) denied by "
+                       "rule 'test rule'.")
+                  (:body response)))))
+       (testing "access denied when cert CN is explicitly denied in the rule"
+         (let [response (ring-handler (testutils/request
+                                       "/path/to/foo"
+                                       :get "127.0.0.1"
+                                       testutils/test-denied-cert))]
+           (is (= 403 (:status response)))
+           (is (= (str "Forbidden request: bad.guy.com(127.0.0.1) access to "
+                       "/path/to/foo (method :get) (authentic: true) denied by "
+                       "rule 'test rule'.")
+                  (:body response))))))
+     (testing "access denied when deny all"
+       (let [app (build-ring-handler [(-> (testutils/new-rule :path "/")
+                                          (rules/deny "*"))]
+                                     false)]
+         (doseq [path ["a" "/" "/hip/hop/" "/a/hippie/to/the/hippi-dee/beat"]]
+           (let [req (testutils/request path
+                                        :get "127.0.0.1"
+                                        testutils/test-domain-cert)
+                 {status :status} (app req)]
+             (is (= status 403)))))))))
+
+(deftest wrap-authorization-check-for-allow-header-cert-info-true-tests
+  (testing "wrap-authorization-check for allow-header-cert-info true results in"
+    (logutils/with-test-logging
+     (let [ring-handler (build-ring-handler test-rule true)]
+       (testing "access allowed when cert CN is allowed"
+         (let [response (ring-handler (-> (testutils/request "/path/to/foo"
+                                                             :get "127.0.0.1")
+                                          (wrap-successful-x-client-cn
+                                           "test.domain.org")))]
+           (is (= 200 (:status response)))
+           (is (= "hello" (:body response)))))
+       (testing "access denied when cert CN is not in the rule"
+         (let [response (ring-handler (-> (testutils/request
+                                           "/path/to/foo"
+                                           :get "127.0.0.1")
+                                          (wrap-successful-x-client-cn
+                                           "www.other.org")))]
+           (is (= 403 (:status response)))
+           (is (= (str "Forbidden request: www.other.org(127.0.0.1) access to "
+                       "/path/to/foo (method :get) (authentic: true) denied by "
+                       "rule 'test rule'.")
+                  (:body response)))))
+       (testing "access denied when cert CN is explicitly denied in the rule"
+         (let [response (ring-handler (-> (testutils/request
+                                           "/path/to/foo"
+                                           :get "127.0.0.1")
+                                          (wrap-successful-x-client-cn
+                                           "bad.guy.com")))]
+           (is (= 403 (:status response)))
+           (is (= (str "Forbidden request: bad.guy.com(127.0.0.1) access to "
+                       "/path/to/foo (method :get) (authentic: true) denied by "
+                       "rule 'test rule'.")
+                  (:body response))))))
+     (testing "access denied when deny all"
+       (let [app (build-ring-handler [(-> (testutils/new-rule :path "/")
+                                          (rules/deny "*"))]
+                                     true)]
+         (doseq [path ["a" "/" "/hip/hop/" "/a/hippie/to/the/hippi-dee/beat"]]
+           (let [req (-> (testutils/request path
+                                            :get "127.0.0.1"
+                                            testutils/test-domain-cert)
+                         (wrap-successful-x-client-cn "test.domain.org"))
+                 {status :status} (app req)]
+             (is (= status 403)))))))))
+
+(deftest authorization-map-wrapped-into-authorized-request
+  (testing "Authorization map wrapped into authorized request when"
+    (let [build-ring-handler (partial
+                              ring-middleware/wrap-authorization-check
+                              (fn [request]
+                                (ring-response/response request))
+                              [(-> (testutils/new-rule :regex "/.*/")
+                                   (assoc :allow-unauthenticated true))])
+          ring-handler-with-allow-header-cert-info-false (build-ring-handler false)
+          ring-handler-with-allow-header-cert-info-true (build-ring-handler true)]
+      (testing "SSL certificate provided and allow-header-cert-info false"
+        (let [response (ring-handler-with-allow-header-cert-info-false
+                        (testutils/request "/path/to/foo" :get "127.0.0.1"
+                                           testutils/test-domain-cert))
+              authorization (get-in response [:body :authorization])]
+          (is (identical? testutils/test-domain-cert (:certificate authorization))
+              "SSL certificate not added to authorization map")
+          (is (true? (:authentic? authorization))
+              "Unexpected authentic? value for authorization map")
+          (is (= "test.domain.org" (:name authorization))
+              "Unexpected name for authorization map")))
+      (testing "no SSL certificate provided and allow-header-cert-info false"
+        (let [response (ring-handler-with-allow-header-cert-info-false
+                        (testutils/request))
+              authorization (get-in response [:body :authorization])]
+          (is (nil? (:certificate authorization))
+              "SSL certificate added to authorization map")
+          (is (false? (:authentic? authorization))
+              "Unexpected authentic? value for authorization map")
+          (is (= "" (:name authorization))
+              "Unexpected name for authorization map")))
+      (testing "header credentials provided and allow-header-cert-info true"
+        (let [response (ring-handler-with-allow-header-cert-info-true
+                        (-> (testutils/request)
+                            (wrap-x-client-cert (testutils/url-encoded-cert
+                                                 testutils/test-domain-cert))
+                            (wrap-x-client-dn "/O=tester/CN=test.domain.org")
+                            (wrap-x-client-verify "SUCCESS")))
+              authorization (get-in response [:body :authorization])]
+          (is (= "test.domain.org"
+                 (ssl-utils/get-cn-from-x509-certificate
+                  (:certificate authorization)))
+              "x-client certificate not added to authorization map")
+          (is (true? (:authentic? authorization))
+              "Unexpected authentic? value for authorization map")
+          (is (= "test.domain.org" (:name authorization))
+              "Unexpected name for authorization map")))
+      (testing "no header credentials provided and allow-header-cert-info true"
+        (let [response (ring-handler-with-allow-header-cert-info-true
+                        (testutils/request))
+              authorization (get-in response [:body :authorization])]
+          (is (nil? (:certificate authorization))
+              "SSL certificate added to authorization map")
+          (is (false? (:authentic? authorization))
+              "Unexpected authentic? value for authorization map")
+          (is (= "" (:name authorization))
+              "Unexpected name for authorization map"))))))

--- a/test/puppetlabs/trapperkeeper/authorization/ring_test.clj
+++ b/test/puppetlabs/trapperkeeper/authorization/ring_test.clj
@@ -6,13 +6,13 @@
 
 (use-fixtures :once schema-test/validate-schemas)
 
-(deftest get-authorized-authentic?
+(deftest authorized-authentic?
   (is (true? (-> (testutils/request)
                  (assoc-in [:authorization :authentic?] true)
-                 (ring/get-authorized-authentic?))))
+                 (ring/authorized-authentic?))))
   (is (false? (-> (testutils/request)
                   (assoc-in [:authorization :authentic?] false)
-                  (ring/get-authorized-authentic?)))))
+                  (ring/authorized-authentic?)))))
 
 (deftest set-authorized-authentic?
   (is (true? (-> (testutils/request)
@@ -22,12 +22,12 @@
                   (ring/set-authorized-authentic? false)
                   (get-in [:authorization :authentic?])))))
 
-(deftest get-authorized-certificate
+(deftest authorized-certificate
   (is (identical? testutils/test-domain-cert
                   (-> (testutils/request)
                       (assoc-in [:authorization :certificate]
                                 testutils/test-domain-cert)
-                      (ring/get-authorized-certificate)))))
+                      (ring/authorized-certificate)))))
 
 (deftest set-authorized-certificate
   (is (identical? testutils/test-domain-cert
@@ -36,12 +36,12 @@
                        testutils/test-domain-cert)
                       (get-in [:authorization :certificate])))))
 
-(deftest get-authorized-name
+(deftest authorized-name
   (is (= "tester" (-> (testutils/request)
                       (assoc-in [:authorization :name] "tester")
-                      (ring/get-authorized-name))))
+                      (ring/authorized-name))))
   (is (= "" (-> (testutils/request)
-                (ring/get-authorized-name)))))
+                (ring/authorized-name)))))
 
 (deftest set-authorized-name
   (is (= "tester" (-> (testutils/request)

--- a/test/puppetlabs/trapperkeeper/authorization/ring_test.clj
+++ b/test/puppetlabs/trapperkeeper/authorization/ring_test.clj
@@ -1,0 +1,52 @@
+(ns puppetlabs.trapperkeeper.authorization.ring-test
+  (:require [clojure.test :refer :all]
+            [puppetlabs.trapperkeeper.authorization.ring :as ring]
+            [puppetlabs.trapperkeeper.authorization.testutils :as testutils]
+            [schema.test :as schema-test]))
+
+(use-fixtures :once schema-test/validate-schemas)
+
+(deftest get-authorized-authentic?
+  (is (true? (-> (testutils/request)
+                 (assoc-in [:authorization :authentic?] true)
+                 (ring/get-authorized-authentic?))))
+  (is (false? (-> (testutils/request)
+                  (assoc-in [:authorization :authentic?] false)
+                  (ring/get-authorized-authentic?)))))
+
+(deftest set-authorized-authentic?
+  (is (true? (-> (testutils/request)
+                 (ring/set-authorized-authentic? true)
+                 (get-in [:authorization :authentic?]))))
+  (is (false? (-> (testutils/request)
+                  (ring/set-authorized-authentic? false)
+                  (get-in [:authorization :authentic?])))))
+
+(deftest get-authorized-certificate
+  (is (identical? testutils/test-domain-cert
+                  (-> (testutils/request)
+                      (assoc-in [:authorization :certificate]
+                                testutils/test-domain-cert)
+                      (ring/get-authorized-certificate)))))
+
+(deftest set-authorized-certificate
+  (is (identical? testutils/test-domain-cert
+                  (-> (testutils/request)
+                      (ring/set-authorized-certificate
+                       testutils/test-domain-cert)
+                      (get-in [:authorization :certificate])))))
+
+(deftest get-authorized-name
+  (is (= "tester" (-> (testutils/request)
+                      (assoc-in [:authorization :name] "tester")
+                      (ring/get-authorized-name))))
+  (is (= "" (-> (testutils/request)
+                (ring/get-authorized-name)))))
+
+(deftest set-authorized-name
+  (is (= "tester" (-> (testutils/request)
+                      (ring/set-authorized-name "tester")
+                      (get-in [:authorization :name]))))
+  (is (= "" (-> (testutils/request)
+                (ring/set-authorized-name nil)
+                (get-in [:authorization :name])))))

--- a/test/puppetlabs/trapperkeeper/authorization/rules_test.clj
+++ b/test/puppetlabs/trapperkeeper/authorization/rules_test.clj
@@ -136,7 +136,7 @@
 (deftest test-allowed
   (logutils/with-test-logging
     (let [request (-> (request "/stairway/to/heaven" :get "192.168.1.23")
-                      (assoc-in ring/is-authentic-key true))]
+                      (ring/set-authorized-authentic? true))]
       (testing "allowed request by name"
         (let [rules (build-rules ["/path/to/resource" "*.domain.org"]
                                  ["/stairway/to/heaven" "*.domain.org"])]
@@ -173,7 +173,7 @@
                   (-> (rules/new-rule :path "/foo" :any 1 "name")
                       (rules/allow "*"))])
           request (-> (request "/foo")
-                      (assoc-in ring/is-authentic-key true))]
+                      (ring/set-authorized-authentic? true))]
       (is (rules/authorized? (rules/allowed? rules request "test.org")))))
   (testing "rules checked in order of name when sort-order is the same"
     (let [rules (rules/sort-rules
@@ -182,5 +182,5 @@
                   (-> (rules/new-rule :path "/foo" :any 1 "aaa")
                       (rules/allow "*"))])
           request (-> (request "/foo")
-                      (assoc-in ring/is-authentic-key true))]
+                      (ring/set-authorized-authentic? true))]
       (is (rules/authorized? (rules/allowed? rules request "test.org"))))))

--- a/test/puppetlabs/trapperkeeper/authorization/testutils.clj
+++ b/test/puppetlabs/trapperkeeper/authorization/testutils.clj
@@ -1,10 +1,15 @@
 (ns puppetlabs.trapperkeeper.authorization.testutils
   (:require [puppetlabs.ssl-utils.simple :as ssl]
             [puppetlabs.trapperkeeper.authorization.rules :as rules]
-            [ring.mock.request :as mock]))
+            [ring.mock.request :as mock]
+            [puppetlabs.ssl-utils.core :as ssl-utils]
+            [ring.util.codec :as ring-codec])
+  (:import (java.io StringWriter)))
 
 (defn request
   "Build a ring request for testing"
+  ([]
+   (request "/path/to/resource" :get))
   ([path method]
    (request path method "127.0.0.1"))
   ([path method ip]
@@ -26,3 +31,9 @@
    (new-rule type path :any))
   ([type path method]
    (rules/new-rule type path method 500 "test rule")))
+
+(defn url-encoded-cert
+  [x509-cert]
+  (let [cert-writer (StringWriter.)
+        _ (ssl-utils/cert->pem! x509-cert cert-writer)]
+    (ring-codec/url-encode cert-writer)))

--- a/test/puppetlabs/trapperkeeper/services/authorization/authorization_core_test.clj
+++ b/test/puppetlabs/trapperkeeper/services/authorization/authorization_core_test.clj
@@ -2,8 +2,7 @@
   (:require [clojure.test :refer :all]
             [puppetlabs.trapperkeeper.services.authorization.authorization-core :refer :all]
             [schema.test]
-            [puppetlabs.kitchensink.core :refer [dissoc-in]]
-            [puppetlabs.trapperkeeper.authorization.rules :as rules]))
+            [puppetlabs.kitchensink.core :refer [dissoc-in]]))
 
 (use-fixtures :once schema.test/validate-schemas)
 
@@ -81,6 +80,14 @@
            IllegalArgumentException
            #"Unsupported or missing version in configuration file.*"
            (validate-auth-config! invalid)))))
+
+  (testing "allow-header-cert-info is a boolean"
+    (is (thrown-with-msg?
+         IllegalArgumentException
+         #"allow-header-cert-info is not a boolean"
+         (validate-auth-config! {:version 1
+                                 :rules []
+                                 :allow-header-cert-info "maybe?"}))))
 
   (testing "Rule names must be unique"
     (is (thrown-with-msg?


### PR DESCRIPTION
This commit adds support for the `allow-header-cert-info` feature, for
controlling whether the request identity should be read from an SSL
certificate (true) or HTTP X-Client headers (false).
