### PR TITLE
(MAINT) Added CHANGELOG.md file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,52 @@
+### 0.1.4
+ * [TK-282](https://tickets.puppetlabs.com/browse/TK-282) Added support for an
+   `allow-header-cert-info` field to the `authorization` config.
+
+### 0.1.3
+
+ * [TK-262](https://tickets.puppetlabs.com/browse/TK-262) Added support for a
+   `version` field to the `authorization` config.
+ * [TK-266](https://tickets.puppetlabs.com/browse/TK-266) Added support for
+   `sort-order` and `name` fields in a rule definition.
+ * [TK-271](https://tickets.puppetlabs.com/browse/TK-271) Added support for more
+   than one `method` to be specified in a rule definition.
+ * [TK-277](https://tickets.puppetlabs.com/browse/TK-277) Use wrapper function
+   for parsing query-params from the Ring request, to avoid prematurely slurping
+   a request body for a request which is a urlencoded form post.
+ * [TK-279](https://tickets.puppetlabs.com/browse/TK-279) Log error-level message
+   when a request is denied.
+ * [TK-280](https://tickets.puppetlabs.com/browse/TK-280) Updated the
+   `README.md` with more documentation on using the trapperkeeper-authorization
+   service from a developer perspective.  Also added a
+   `doc/authorization-config.md` page which documents the available settings in
+   the `authorization` configuration.
+ * Created simple standalone Ring-based example which integrates with
+   trapperkeeper-authorization.
+
+### 0.1.2
+ * [TK-259](https://tickets.puppetlabs.com/browse/TK-259) Added support for
+   matching rules on `query-params` from the request.
+ * [TK-260](https://tickets.puppetlabs.com/browse/TK-260) Added optional
+   `allow-unauthenticated` attribute to the rule definition to be used for
+   specifying that a rule would match any request - whether or not an
+   authenticated name could be derived for the request.
+ * [TK-272](https://tickets.puppetlabs.com/browse/TK-272) Fixed ability for the
+   `deny: "*"` directive to deny - rather than allow - all matching requests.
+ * [TK-275](https://tickets.puppetlabs.com/browse/TK-275) Move elements of the
+   rule definition which determine whether the rule is a match for the request
+   into a `match-request` section.
+
+### 0.1.1
+ * [TK-258](https://tickets.puppetlabs.com/browse/TK-258) Created a Trapperkeeper
+   service, AuthorizationService, with a `wrap-with-authorization-check`
+   function for accessing the authorization middleware from another service.
+   Rules loaded from `authorization` section in Trapperkeeper configuration.
+ * Removed ability to obtain the request's authenticated name from a
+   reverse-proxy DNS lookup when no name can be retrieved from the client
+   certificate on the request.
+ * Bumped `puppetlabs/ssl-utils` dependency from 0.8.0 to 0.8.1.
+ * Authorization failures returned as HTTP 403 instead of 401.
+
+### 0.0.1
+ * Not released by PuppetLabs.  Code imported from the 0.0.1 tag on
+   https://github.com/masterzen/trapperkeeper-authorization.

--- a/doc/authorization-config.md
+++ b/doc/authorization-config.md
@@ -283,7 +283,11 @@ A block in the middle of the `sort-order` range - from 400 to 600
 (inclusive) is reserved for use by Puppet, e.g., for the default rules 
 delivered with a package.  Rules from 1 to 399 (inclusive) are reserved for 
 users to insert custom rules ahead of any default Puppet ones and from 601 to
-999 (inclusive) for inserting custom rules behind any default Puppet ones.
+998 (inclusive) for inserting custom rules behind any default Puppet ones.
+
+The 999 `sort-order` is reserved for a Puppet rule that denies all users access
+to all routes in the event that no other rule in the configuration was a match
+for the request.
 
 #### `name`
 


### PR DESCRIPTION
This commit adds a CHANGELOG.md file and includes info for releases from
0.1.1 to the forthcoming 0.1.4.  This commit also has a small update to
the `sort-order` documentation, indicating that 999 is now considered a
reserved value for Puppet - the position of the "default deny" rule.
