### PR TITLE
[FOR REVIEW ONLY - DO NOT MERGE] (TK-261) Rule matching logging

### DIFF
--- a/src/puppetlabs/trapperkeeper/authorization/report.clj
+++ b/src/puppetlabs/trapperkeeper/authorization/report.clj
@@ -1,0 +1,68 @@
+(ns puppetlabs.trapperkeeper.authorization.report
+  (:require [schema.core :as schema]
+            [puppetlabs.trapperkeeper.authorization.ring :refer [Request]]
+            [clojure.string :as str]
+            [inet.data.ip :as ip]))
+
+;; Schemas
+
+(def Match
+  "A rule can either match, not match, never been tested or been unconditionnally authenticated"
+  (schema/enum :yes :no :skipped :allow-unauthenticated))
+
+(def EntryReport
+  "Report for an Entry test during a match"
+  {:pattern schema/Str :type (schema/enum :allow :deny) :match Match})
+
+(def ACLReport
+  "Report for matching a list of Entry"
+  [EntryReport])
+
+(def RuleReport
+  {:rule schema/Str :match Match :acl-match ACLReport}  )
+
+(def Report
+  "A textual report of a rules match"
+  {:request {:path schema/Str :method schema/Str :name schema/Str :ip schema/Str}
+   :matches [RuleReport]
+   })
+
+;; Report handling
+
+(schema/defn new-report :- Report
+  "Creates a new report from an incoming Request and client name"
+  [request :- Request
+   name :- schema/Str]
+  (let [{ method :request-method uri :uri ip :remote-addr}  request]
+    {:request {:path uri :method (str/upper-case (clojure.core/name method)) :name name :ip ip}
+     :matches []}))
+
+(schema/defn deny-all :- Report
+  "Changes a report in the case of a deny all"
+  [report :- Report]
+  report)
+
+(schema/defn append-rule-report :- Report
+  "Append a RuleReport to a given report"
+  [rule-report :- RuleReport
+   report :- Report]
+  (assoc report :matches (conj (:matches report) rule-report)))
+
+(schema/defn merge-acl-report :- Report
+  [acl-report :- ACLReport
+   rule-name :- schema/Str
+   report :- Report]
+  (letfn [(inject-acl-report [rule-report] (if (= (:rule rule-report) rule-name)
+                                               (assoc rule-report :acl-match acl-report)
+                                               rule-report))]
+    (assoc report :matches (mapv inject-acl-report (:matches report)))))
+
+(defn new-acl-report
+  "Creates a blank ACLReport"
+  [])
+
+(schema/defn append-acl-report :- ACLReport
+  "Append one entry to a given acl report"
+  [report :- ACLReport
+   entry :- EntryReport]
+  (conj report entry))

--- a/test/puppetlabs/trapperkeeper/authorization/report_test.clj
+++ b/test/puppetlabs/trapperkeeper/authorization/report_test.clj
@@ -1,0 +1,48 @@
+(ns puppetlabs.trapperkeeper.authorization.report-test
+  (:require [clojure.test :refer :all]
+            [schema.test :as schema-test]
+            [puppetlabs.trapperkeeper.authorization.report :as report]
+            [puppetlabs.trapperkeeper.authorization.testutils :refer [request]]))
+
+(use-fixtures :once schema-test/validate-schemas)
+
+(deftest test-new-report-from-request
+  (let [report (report/new-report (request "here") "www.domain.org")]
+    (testing "should embed the request"
+      (is (= {:path "here" :method "GET" :ip "127.0.0.1" :name "www.domain.org"} (:request report))))
+    (testing "should have no matches"
+      (is (= 0 (count (:matches report)))))))
+
+(deftest test-append-rule-report
+  (let [blank-report (report/new-report (request "here") "www.domain.org")
+        report (report/append-rule-report {:rule "path/to/resource" :match :no :acl-match []} blank-report)]
+    (testing "should add one entry"
+      (is (= 1 (count (:matches report))))
+      (is (= {:rule "path/to/resource" :match :no :acl-match []} (first (:matches report)))))))
+
+(deftest test-new-acl-report
+  (testing "empty acl report is empty"
+    (is (= 0 (count (report/new-acl-report))))))
+
+(deftest test-appending-acl-report
+  (testing "appending one acl report"
+    (let [report (-> (report/new-acl-report)
+                     (report/append-acl-report {:pattern "test.domain.org" :type :allow :match :yes}))]
+      (is (= 1 (count report)))
+      (is (= {:pattern "test.domain.org" :type :allow :match :yes} (first report))))))
+
+(deftest test-set-acl-report
+  (let [report (->> (report/new-report (request "here") "www.domain.org")
+                    (report/append-rule-report {:rule "path/to/resource" :match :no :acl-match []})
+                    (report/append-rule-report {:rule "other/resource" :match :yes :acl-match []})
+                    (report/append-rule-report {:rule "third/resource" :match :skipped :acl-match []})
+                    (report/merge-acl-report [{:pattern "*.daysofwonder.com" :type :allow :match :no}
+                                              {:pattern "127.0.0.0/8" :type :deny :match :yes}
+                                              ] "other/resource"))
+        ]
+    (testing "should add an acl report to the right rule"
+      (is (= 3 (count (:matches report))))
+      (is (= [0 2 0] (map #(count (:acl-match %)) (:matches report))))
+      (is (= [{:pattern "*.daysofwonder.com" :type :allow :match :no}
+              {:pattern "127.0.0.0/8" :type :deny :match :yes}
+              ] (:acl-match (nth (:matches report) 1)))))))

--- a/test/puppetlabs/trapperkeeper/authorization/testutils.clj
+++ b/test/puppetlabs/trapperkeeper/authorization/testutils.clj
@@ -3,13 +3,16 @@
             [puppetlabs.trapperkeeper.authorization.rules :as rules]
             [ring.mock.request :as mock]
             [puppetlabs.ssl-utils.core :as ssl-utils]
-            [ring.util.codec :as ring-codec])
+            [ring.util.codec :as ring-codec]
+            [clojure.test :refer :all])
   (:import (java.io StringWriter)))
 
 (defn request
   "Build a ring request for testing"
   ([]
    (request "/path/to/resource" :get))
+  ([path]
+   (request path :get "127.0.0.1"))
   ([path method]
    (request path method "127.0.0.1"))
   ([path method ip]
@@ -37,3 +40,10 @@
   (let [cert-writer (StringWriter.)
         _ (ssl-utils/cert->pem! x509-cert cert-writer)]
     (ring-codec/url-encode cert-writer)))
+
+(defmacro is-allowed
+  [form] `(try-expr nil (:result ~form)))
+
+(defmacro is-not-allowed
+  [form] `(try-expr nil (not (:result ~form))))
+


### PR DESCRIPTION
This is a partial implementation of [TK-261](https://tickets.puppetlabs.com/browse/TK-261) which for the moment tackles the match logging by producing a `Report` that describes as a data-structure what happened internally during an authorization. This was ported from my old tk-authz and reworked/fixed during the Puppet Contributor Summit.

Basically upon calling `rules/allowed?`, the caller will also receive a `report/Report` containing a description of the incoming request, the list of rules that were not matching, matching and skipped. And for the one rule that matched, an ACL report is returned, describing which ACE triggered.

Note: this PR is not finished as it doesn't provide anything to do the logging, and doesn't exploit new tk-authz feature like rules identifier.

Let me know if this is going in the right direction or not.
