### PR TITLE
(TK-261) Rule-by-rule logging 

### DIFF
--- a/src/puppetlabs/trapperkeeper/authorization/ring_middleware.clj
+++ b/src/puppetlabs/trapperkeeper/authorization/ring_middleware.clj
@@ -207,7 +207,7 @@
   (let [name (request->name request allow-header-cert-info)]
     (->
       request
-      (ring/set-authorized-name (str name))
+      (ring/set-authorized-name name)
       (ring/set-authorized-authentic? (and
                                        (verified? request
                                                   name
@@ -249,8 +249,7 @@
    allow-header-cert-info :- schema/Bool]
   (fn [request]
     (let [req (add-authinfo request allow-header-cert-info)
-          name (ring/authorized-name req)
-          {:keys [authorized message]} (rules/allowed? rules req name)]
+          {:keys [authorized message]} (rules/allowed? rules req)]
       (if (true? authorized)
         (handler req)
         (-> (ring-response/response message)

--- a/src/puppetlabs/trapperkeeper/authorization/ring_middleware.clj
+++ b/src/puppetlabs/trapperkeeper/authorization/ring_middleware.clj
@@ -245,7 +245,7 @@
 (schema/defn wrap-authorization-check :- IFn
   "A ring middleware that checks the request is allowed by the provided rules"
   [handler :- IFn
-   rules :- rules/Rules
+   rules :- [rules/Rule]
    allow-header-cert-info :- schema/Bool]
   (fn [request]
     (let [req (add-authinfo request allow-header-cert-info)

--- a/src/puppetlabs/trapperkeeper/authorization/rules.clj
+++ b/src/puppetlabs/trapperkeeper/authorization/rules.clj
@@ -111,6 +111,22 @@
             (some (get rule-params k)
                   (flatten [(get request-params (name k))])))))
 
+(schema/defn sort-rules :- [Rule]
+  "Sorts the rules based on their :sort-order, and then their :name if they
+   have the same sort order value."
+  [rules :- [Rule]]
+  (sort-by (juxt :sort-order :name) rules))
+
+(schema/defn requestor :- schema/Str
+  "Returns a string that identifies the source of the request containing
+   at least the IP address and the hostname if available."
+  [request :- ring/Request]
+  (let [ip (:remote-addr request)
+        name (ring/authorized-name request)]
+    (if (empty? name)
+      (str ip)
+      (format "%s(%s)" name ip))))
+
 (schema/defn match? :- (schema/maybe RuleMatch)
   "Returns the rule if it matches the request URI, and also
    any capture groups of the Rule pattern if there are any."
@@ -119,30 +135,48 @@
   (if (and (method-match? (:request-method request) (:method rule))
            (query-params-match? (:query-params request) (:query-params rule)))
     (if-let [matches (re-find* (:path rule) (:uri request))]
-      {:rule rule :matches (into [] (rest matches))})))
+      {:rule rule :matches (into [] (rest matches))}
+      (log/tracef
+       "Request to '%s' from '%s' did not match rule '%s' - continuing matching"
+       (:uri request) (requestor request) (:name rule)))))
 
 (defn- request->description
-  [request name rule]
-  (let [ip (:remote-addr request)
+  [request rule]
+  (let [from (requestor request)
         path (:uri request)
         method (:request-method request)
         authentic? (true? (ring/authorized-authentic? request))]
-    (str "Forbidden request: " (if name (format "%s(%s)" name ip) ip)
-         " access to " path " (method " method ")"
+    (str "Forbidden request: " from " access to " path " (method " method ")"
          (if-let [file (:file rule)] (str " at " file ":" (:line rule)))
          (format " (authentic: %s) " authentic?)
          (format "denied by rule '%s'." (:name rule)))))
 
-(schema/defn sort-rules :- [Rule]
-  "Sorts the rules based on their :sort-order, and then their :name if they
-   have the same sort order value."
-  [rules :- [Rule]]
-  (sort-by (juxt :sort-order :name) rules))
+(schema/defn allow-request :- AuthorizationResult
+  "Logs debugging information about the request and rule at the TRACE level
+   and returns an authorized authorization result with the provided message."
+  [request :- ring/Request
+   rule :- Rule
+   message :- schema/Str]
+  (log/tracef
+   "Request to '%s' from '%s' handled by rule '%s' - request allowed"
+   (:uri request) (requestor request) (:name rule))
+  {:authorized true
+   :message message})
 
 (schema/defn deny-request :- AuthorizationResult
-  "Logs the reason message at ERROR level and
-   returns an unauthorized authorization result."
-  [reason :- schema/Str]
+  "Logs debugging information about the request and rule at the TRACE level
+   as well as the reason for denial at the ERROR level, and returns an
+   unauthorized authorization result with the provided reason message."
+  [request :- ring/Request
+   rule :- (schema/maybe Rule)
+   reason :- schema/Str]
+  (if rule
+    (log/tracef
+     "Request to '%s' from '%s' handled by rule '%s' - request denied"
+     (:uri request) (requestor request) (:name rule))
+    (log/tracef
+     "Request to '%s' from '%s' did not match any rules - request denied"
+     (:uri request) (requestor request)))
   (log/error reason)
   {:authorized false
    :message reason})
@@ -153,16 +187,15 @@
   "Checks if a request is allowed access given the list of rules. Rules
    will be checked in the given order; use `sort-rules` to first sort them."
   [rules :- [Rule]
-   request :- ring/Request
-   name :- schema/Str]
+   request :- ring/Request]
   (if-let [{:keys [rule matches]} (some #(match? % request) rules)]
     (if (true? (:allow-unauthenticated rule))
-      {:authorized true :message "allow-unauthenticated is true - allowed"}
-      (if (and (true? (ring/authorized-authentic? request)) ; authenticated?
-               (acl/allowed? (:acl rule) name matches))
-        {:authorized true :message ""}
-        (deny-request (request->description request name rule))))
-    (deny-request "global deny all - no rules matched")))
+      (allow-request request rule "allow-unauthenticated is true - allowed")
+      (if (and (true? (ring/authorized-authentic? request))
+               (acl/allowed? (:acl rule) (ring/authorized-name request) matches))
+        (allow-request request rule "")
+        (deny-request request rule (request->description request rule))))
+    (deny-request request nil "global deny all - no rules matched")))
 
 (schema/defn authorized? :- schema/Bool
   [result :- AuthorizationResult]

--- a/src/puppetlabs/trapperkeeper/authorization/rules.clj
+++ b/src/puppetlabs/trapperkeeper/authorization/rules.clj
@@ -32,9 +32,9 @@
   (schema/maybe {:rule Rule :matches [schema/Str]}))
 
 (def AuthorizationResult
-  "A result returned by rules/allowed? that can be either authorized or non-authorized. If non-authorized it also
-  contains an explanation message"
-  { :authorized schema/Bool :message schema/Str })
+  "A result returned by rules/allowed? that can be either authorized or
+  non-authorized. If non-authorized it also contains an explanation message"
+  {:authorized schema/Bool :message schema/Str})
 
 ;; Rule creation
 
@@ -45,14 +45,14 @@
    method :- Methods
    sort-order :- schema/Int
    name :- schema/Str]
-   {:type type
-    :path (condp = type
-            :path (re-pattern (str "^" (Pattern/quote path)))
-            :regex (re-pattern path))
-    :acl acl/empty-acl
-    :method method
-    :sort-order sort-order
-    :name name})
+  {:type type
+   :path (condp = type
+           :path (re-pattern (str "^" (Pattern/quote path)))
+           :regex (re-pattern path))
+   :acl acl/empty-acl
+   :method method
+   :sort-order sort-order
+   :name name})
 
 (schema/defn tag-rule :- Rule
   "Tag a rule with a file/line - useful for instance when the rule has been read
@@ -122,7 +122,7 @@
    request :- ring/Request]
   (if (and (method-match? (:request-method request) (:method rule))
            (query-params-match? (:query-params request) (:query-params rule)))
-    (if-let [matches (re-find* (:path rule) (:uri request))] ;; check rule against request uri
+    (if-let [matches (re-find* (:path rule) (:uri request))]
       {:rule rule :matches (into [] (rest matches))})))
 
 (defn- request->description
@@ -172,7 +172,7 @@
     (if (true? (:allow-unauthenticated rule))
       {:authorized true :message "allow-unauthenticated is true - allowed"}
       (if (and (true? (ring/authorized-authentic? request)) ; authenticated?
-            (acl/allowed? (:acl rule) name matches))
+               (acl/allowed? (:acl rule) name matches))
         {:authorized true :message ""}
         (deny-request (request->description request name rule))))
     (deny-request "global deny all - no rules matched")))

--- a/src/puppetlabs/trapperkeeper/services/authorization/authorization_core.clj
+++ b/src/puppetlabs/trapperkeeper/services/authorization/authorization_core.clj
@@ -15,8 +15,8 @@
 
 (def acl-func-map
   "A function map to allow a programmatic execution of allow/deny directives"
-  {:allow #(rules/allow %1 %2)
-   :deny #(rules/deny %1 %2)})
+  {:allow rules/allow
+   :deny rules/deny})
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Private
@@ -231,7 +231,7 @@
                    "Rules must be uniquely named.")))))
   config)
 
-(schema/defn transform-config :- rules/Rules
+(schema/defn transform-config :- [rules/Rule]
   "Transforms the (validated) authorization service config into a list of Rules
    that work with the authorization code. Assumes config has been validated via
    `validate-auth-config!`. A warning is logged if the rules in the config are

--- a/src/puppetlabs/trapperkeeper/services/authorization/authorization_core.clj
+++ b/src/puppetlabs/trapperkeeper/services/authorization/authorization_core.clj
@@ -14,7 +14,7 @@
   #{"get" "post" "put" "delete" "head"})
 
 (def acl-func-map
-  "This is a function map to allow a programmatic execution of allow/deny directives"
+  "A function map to allow a programmatic execution of allow/deny directives"
   {:allow #(rules/allow %1 %2)
    :deny #(rules/deny %1 %2)})
 
@@ -78,8 +78,8 @@
       (add-query-params m)))
 
 (defn valid-method?
-  "Returns true if the given rule contains either a valid method, or no speicfied
-  method."
+  "Returns true if the given rule contains either a valid method,
+  or no specified method."
   [rule]
   (let [rule-method (get-in rule [:match-request :method])
         method (if (string? rule-method) [rule-method] rule-method)]
@@ -124,12 +124,12 @@
   (if (:allow-unauthenticated rule)
     (if (some #{:deny :allow} (keys rule))
       (throw (IllegalArgumentException.
-               (str "Authorization rule specified as  " (pprint-rule rule)
-                 " cannot have allow or deny if allow-unauthenticated."))))
+              (str "Authorization rule specified as  " (pprint-rule rule)
+                   " cannot have allow or deny if allow-unauthenticated."))))
     (when-not (some #{:deny :allow} (keys rule))
       (throw (IllegalArgumentException.
-               (str "Authorization rule specified as " (pprint-rule rule)
-                 " must contain either a 'deny' or 'allow' rule.")))))
+              (str "Authorization rule specified as " (pprint-rule rule)
+                   " must contain either a 'deny' or 'allow' rule.")))))
   (when-not (string? (:type (:match-request rule)))
     (throw (IllegalArgumentException.
             (str "The type set in the authorization rule specified "
@@ -148,11 +148,11 @@
                  "It should be a string."))))
   (when-not (valid-method? rule)
     (throw (IllegalArgumentException.
-             (str "The method specified in the authorization rule specified as "
-                  (pprint-rule rule) " is invalid. "
-                  "It should be either a string or list of strings that is equal "
-                  "to one of the following methods: '"
-                  (str/join "', '" (sort valid-methods)) "'"))))
+            (str "The method specified in the authorization rule specified as "
+                 (pprint-rule rule) " is invalid. "
+                 "It should be either a string or list of strings that is "
+                 "equal to one of the following methods: '"
+                 (str/join "', '" (sort valid-methods)) "'"))))
   (when (= "regex" (-> rule :match-request :type name str/lower-case))
     (try
       (re-pattern (:path (:match-request rule)))

--- a/src/puppetlabs/trapperkeeper/services/authorization/authorization_service.clj
+++ b/src/puppetlabs/trapperkeeper/services/authorization/authorization_service.clj
@@ -1,7 +1,9 @@
 (ns puppetlabs.trapperkeeper.services.authorization.authorization-service
-  (:require [puppetlabs.trapperkeeper.authorization.ring-middleware :as
+  (:require [clojure.tools.logging :as log]
+            [puppetlabs.trapperkeeper.authorization.ring-middleware :as
              ring-middleware]
             [puppetlabs.trapperkeeper.core :refer [defservice]]
+            [puppetlabs.kitchensink.core :as ks]
             [puppetlabs.trapperkeeper.services.authorization.authorization-core :refer :all]
             [puppetlabs.trapperkeeper.services :refer [service-context]]))
 
@@ -12,19 +14,20 @@
   AuthorizationService
   [[:ConfigService get-in-config]]
   (init
-    [this context]
-    (let [config (get-in-config [:authorization])]
-      (validate-auth-config! config)
-      (-> context
-          (assoc-in [:rules] (transform-config (:rules config)))
-          (assoc-in [:allow-header-cert-info] (get config
-                                                   :allow-header-cert-info
-                                                   false)))))
+   [this context]
+   (let [config (get-in-config [:authorization])
+         rules (-> config validate-auth-config! :rules transform-config)]
+     (log/debug "Transformed auth.conf rules:\n" (ks/pprint-to-string rules))
+     (-> context
+         (assoc-in [:rules] rules)
+         (assoc-in [:allow-header-cert-info] (get config
+                                                  :allow-header-cert-info
+                                                  false)))))
 
   (wrap-with-authorization-check
-    [this handler]
-    (let [{:keys [allow-header-cert-info rules]} (service-context this)]
-      (-> handler
-          (ring-middleware/wrap-authorization-check rules allow-header-cert-info)
-          ring-middleware/wrap-query-params
-          ring-middleware/wrap-with-error-handling))))
+   [this handler]
+   (let [{:keys [allow-header-cert-info rules]} (service-context this)]
+     (-> handler
+         (ring-middleware/wrap-authorization-check rules allow-header-cert-info)
+         ring-middleware/wrap-query-params
+         ring-middleware/wrap-with-error-handling))))

--- a/test/puppetlabs/trapperkeeper/authorization/acl_test.clj
+++ b/test/puppetlabs/trapperkeeper/authorization/acl_test.clj
@@ -93,19 +93,19 @@
                                 (acl/allow "my.domain.com")
                                 (acl/deny "*.domain.com")
                                 (acl/deny "my.domain.com")
-                                ((partial into []))))))
+                                vec))))
       (testing "when deny ACEs added first"
         (is (= expected-acl (-> (acl/deny "*.domain.com")
                                 (acl/deny "my.domain.com")
                                 (acl/allow "*.domain.com")
                                 (acl/allow "my.domain.com")
-                                ((partial into []))))))
+                                vec))))
       (testing "when ACEs added in mixed order"
         (is (= expected-acl (-> (acl/allow "*.domain.com")
                                 (acl/deny "*.domain.com")
                                 (acl/deny "my.domain.com")
                                 (acl/allow "my.domain.com")
-                                ((partial into [])))))))))
+                                vec)))))))
 
 (deftest test-acl-matching
   (let [acl (-> (acl/allow "*.domain.com")

--- a/test/puppetlabs/trapperkeeper/authorization/rules_test.clj
+++ b/test/puppetlabs/trapperkeeper/authorization/rules_test.clj
@@ -117,9 +117,9 @@
 (defn- build-rules
   "Build a list of rules from individual vectors of [path allow]"
   [& rules]
-  (reduce #(rules/add-rule %1 (-> (testutils/new-rule :path (first %2))
-                                  (rules/allow (second %2))))
-          rules/empty-rules
+  (reduce #(conj %1 (-> (testutils/new-rule :path (first %2))
+                        (rules/allow (second %2))))
+          []
           rules))
 
 (deftest test-allowed

--- a/test/puppetlabs/trapperkeeper/services/authorization/authorization_service_test.clj
+++ b/test/puppetlabs/trapperkeeper/services/authorization/authorization_service_test.clj
@@ -213,7 +213,7 @@
           req (assoc catalog-request-nocert :body "Hello World!")
           {:keys [status body]} (app req)]
       (is (= status 403))
-      (is (= body (str "Forbidden request: (127.0.0.1) "
+      (is (= body (str "Forbidden request: 127.0.0.1 "
                        "access to /puppet/v3/catalog/localhost "
                        "(method :get) (authentic: false) "
                        "denied by rule 'puppetlabs catalog'.")))))


### PR DESCRIPTION
This commit adds logging during service start-up that prints the parsed
rules, and logging during request matching that shows each rule as it's
being evaluated.

---

You can see what the log output looks like here: https://gist.github.com/nwolfe/e278f6d4383ffe5578aa
- Start-up logging of parsed rules: https://gist.github.com/nwolfe/e278f6d4383ffe5578aa#file-puppetserver-log-L2-L104
- Rule-by-rule logging during matching: https://gist.github.com/nwolfe/e278f6d4383ffe5578aa#file-puppetserver-log-L179-L192
