### PR TITLE
(PE-7742) Add authorization-check function

### DIFF
--- a/src/puppetlabs/trapperkeeper/authorization/ring_middleware.clj
+++ b/src/puppetlabs/trapperkeeper/authorization/ring_middleware.clj
@@ -15,6 +15,12 @@
            (java.io StringReader)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;; Schemas
+
+(def AuthResultWithRequest
+  (assoc rules/AuthorizationResult :req ring/Request))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Private
 
 (def header-cert-name
@@ -242,15 +248,25 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Public
 
+(schema/defn authorization-check :- AuthResultWithRequest
+  "A function that checks that the request is allowed by the provided rules.
+  Returns a map with the request with auth info added, whether the request is
+  authorized, and a message."
+  [request :- ring/Request
+   rules :- rules/Rules
+   allow-header-cert-info :- schema/Bool]
+  (let [req (add-authinfo request allow-header-cert-info)
+        name (ring/authorized-name req)]
+     (assoc (rules/allowed? rules req name) :req req)))
+
 (schema/defn wrap-authorization-check :- IFn
   "A ring middleware that checks the request is allowed by the provided rules"
   [handler :- IFn
    rules :- rules/Rules
    allow-header-cert-info :- schema/Bool]
   (fn [request]
-    (let [req (add-authinfo request allow-header-cert-info)
-          name (ring/authorized-name req)
-          {:keys [authorized message]} (rules/allowed? rules req name)]
+    (let [{:keys [authorized message req]}
+          (authorization-check request rules allow-header-cert-info)]
       (if (true? authorized)
         (handler req)
         (-> (ring-response/response message)

--- a/src/puppetlabs/trapperkeeper/services/authorization/authorization_service.clj
+++ b/src/puppetlabs/trapperkeeper/services/authorization/authorization_service.clj
@@ -6,7 +6,8 @@
             [puppetlabs.trapperkeeper.services :refer [service-context]]))
 
 (defprotocol AuthorizationService
-  (wrap-with-authorization-check [this handler]))
+  (wrap-with-authorization-check [this handler])
+  (authorization-check [this request]))
 
 (defservice authorization-service
   AuthorizationService
@@ -20,6 +21,9 @@
           (assoc-in [:allow-header-cert-info] (get config
                                                    :allow-header-cert-info
                                                    false)))))
+  (authorization-check [this request]
+   (let [{:keys [rules allow-header-cert-info]} (service-context this)]
+    (ring-middleware/authorization-check request rules allow-header-cert-info)))
 
   (wrap-with-authorization-check
     [this handler]


### PR DESCRIPTION
Previously, it was only possible to execute an authorization check using
`wrap-with-authorization-check`, which only works on Ring requests. This
commit factors out the authorization-checking logic into its own service
function, `authorization-check`.

With this function, it should be possible to perform an authorization check on
a servlet request.
