### PR TITLE
(PE-7742) Add authorization-check function

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,8 @@ This is the protocol for the current implementation of the `:AuthorizationServic
 
 ~~~~clj
 (defprotocol AuthorizationService
-  (wrap-with-authorization-check [this handler]))
+  (wrap-with-authorization-check [this handler])
+  (authorization-check [this request]))
 ~~~~
 
 ### `wrap-with-authorization-check`
@@ -132,6 +133,19 @@ following key/value pairs:
 headers to spaces for some reason and trapperkeeper-authorization can't URL
 decode the result.  We're tracking this issue as
 [SERVER-217](https://tickets.puppetlabs.com/browse/SERVER-217).
+
+### `authorization-check`
+
+A function for directly checking whether a request is authorized or not.
+Useful if you'd like to take more control of the behavior than what
+`wrap-authorization-check` allows for, such as if you've got a servlet request.
+
+The result of this function contains the authorization boolean as well as a
+user-friendly message if it's denied, and some meta-information like the
+request in question. The request will be updated to include things like
+destructured query parameters and authorization information.
+See the [`wrap-with-authorization-check`](#wrap-with-authorization-check)
+section for more information on the authorization information.
 
 ## Credits
 

--- a/src/puppetlabs/trapperkeeper/services/authorization/authorization_service.clj
+++ b/src/puppetlabs/trapperkeeper/services/authorization/authorization_service.clj
@@ -34,5 +34,4 @@
    (let [{:keys [allow-header-cert-info rules]} (service-context this)]
      (-> handler
          (ring-middleware/wrap-authorization-check rules allow-header-cert-info)
-         ring-middleware/wrap-query-params
          ring-middleware/wrap-with-error-handling))))

--- a/src/puppetlabs/trapperkeeper/services/authorization/authorization_service.clj
+++ b/src/puppetlabs/trapperkeeper/services/authorization/authorization_service.clj
@@ -8,7 +8,8 @@
             [puppetlabs.trapperkeeper.services :refer [service-context]]))
 
 (defprotocol AuthorizationService
-  (wrap-with-authorization-check [this handler]))
+  (wrap-with-authorization-check [this handler])
+  (authorization-check [this request]))
 
 (defservice authorization-service
   AuthorizationService
@@ -23,6 +24,10 @@
          (assoc-in [:allow-header-cert-info] (get config
                                                   :allow-header-cert-info
                                                   false)))))
+
+  (authorization-check [this request]
+   (let [{:keys [rules allow-header-cert-info]} (service-context this)]
+    (ring-middleware/authorization-check request rules allow-header-cert-info)))
 
   (wrap-with-authorization-check
    [this handler]


### PR DESCRIPTION
Previously, it was only possible to execute an authorization check using
`wrap-with-authorization-check`, which only works on Ring requests. This
commit factors out the authorization-checking logic into its own service
function, `authorization-check`.

With this function, it should be possible to perform an authorization check on
a servlet request.

---

This commit merges the `AuthResultWithRequest` into the existing
`AuthorizationResult`, so now all authorization results contain the
request in question.

Query parameter destructuring has now been moved into the new
`authorization-check` function, and the existing
`wrap-with-authorization-check` has been refactored to call it. This
allows for `wrap-with-query-params` to be removed.

Added a test for the new `authorization-check` function which also
covers query parameter support and the newly returned (and updated)
request in the authorization result.
