### PR TITLE
(maint) Code Clean Up

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ pom.xml.asc
 .lein-repl-history
 .lein-plugins/
 .lein-failures
+.nrepl-port

--- a/src/puppetlabs/trapperkeeper/authorization/acl.clj
+++ b/src/puppetlabs/trapperkeeper/authorization/acl.clj
@@ -11,7 +11,6 @@
   {:auth-type auth-type
   :type (schema/enum :domain :opaque :regex :dynamic)
   :qualifier (schema/enum :exact :inexact)
-  :length (schema/maybe schema/Int)
   :pattern schema/Any})
 
 (def ACL
@@ -59,7 +58,6 @@
     {:auth-type type
      :type :regex
      :qualifier :exact
-     :length nil
      :pattern #"^*$"}
 
     ; exact domain
@@ -67,7 +65,6 @@
     {:auth-type type
      :type :domain
      :qualifier :exact
-     :length nil
      :pattern (munge-name pattern)}
 
     ; *.domain.com
@@ -76,7 +73,6 @@
       {:auth-type type
        :type :domain
        :qualifier :inexact
-       :length (count host_sans_star)
        :pattern host_sans_star})
 
     ; backreference
@@ -84,7 +80,6 @@
     {:auth-type type
      :type :dynamic
      :qualifier :exact
-     :length nil
      :pattern (munge-name pattern)}
 
     ; opaque string
@@ -92,7 +87,6 @@
     {:auth-type type
      :type :opaque
      :qualifier :exact
-     :length nil
      :pattern [pattern]}
 
     ; regex
@@ -100,7 +94,6 @@
     {:auth-type type
      :type :regex
      :qualifier :inexact
-     :length nil
      :pattern (str/replace pattern #"^/(.*)/$" "$1")}
 
     :else

--- a/src/puppetlabs/trapperkeeper/authorization/acl.clj
+++ b/src/puppetlabs/trapperkeeper/authorization/acl.clj
@@ -4,10 +4,10 @@
 ;; Schemas
 
 (def AuthType (schema/enum :allow :deny))
-(def EntryPattern (schema/pred #(some nil? [(schema/check String %)
-                                            (schema/check [String] %)
-                                            (schema/check schema/Regex %)])
-                               "Entry Pattern must be a string, list of strings, or Regex"))
+(def EntryPattern (schema/conditional
+                   string? String
+                   sequential? [String]
+                   :else schema/Regex))
 
 (def Entry
   "An authorization entry matching a network or a domain"

--- a/src/puppetlabs/trapperkeeper/authorization/acl.clj
+++ b/src/puppetlabs/trapperkeeper/authorization/acl.clj
@@ -48,14 +48,13 @@
 
 (schema/defn ^:private split-domain :- [String]
   "Given a domain string, split it on '.' and reverse it. For examples,
-  'sylvia.plath.net' becomes ['net' 'plath' 'sylvia']. This is used for domain
+  'sylvia.plath.net' becomes ('net' 'plath' 'sylvia'). This is used for domain
   matching."
-  [pattern :- String]
-  (-> pattern
+  [domain :- String]
+  (-> domain
       (clojure.string/lower-case)
       (clojure.string/split #"\.")
-      reverse
-      vec))
+      reverse))
 
 (schema/defn new-domain :- Entry
   "Creates a new ACE for a domain"
@@ -125,7 +124,7 @@
   (if (= (:match ace) :backreference)
     (new-domain (ace :auth-type)
                 (clojure.string/join "." (map #(substitute-backreference % captures)
-                                   (reverse (ace :pattern)))))
+                                              (reverse (ace :pattern)))))
     ace))
 
 (schema/defn match? :- schema/Bool

--- a/src/puppetlabs/trapperkeeper/authorization/acl.clj
+++ b/src/puppetlabs/trapperkeeper/authorization/acl.clj
@@ -1,17 +1,19 @@
 (ns puppetlabs.trapperkeeper.authorization.acl
-  (:require [schema.core :as schema]
-            [clojure.string :as str]))
+  (:require [schema.core :as schema]))
 
 ;; Schemas
 
-(def auth-type (schema/enum :allow :deny))
+(def AuthType (schema/enum :allow :deny))
+(def EntryPattern (schema/pred #(some nil? [(schema/check String %)
+                                            (schema/check [String] %)
+                                            (schema/check schema/Regex %)])
+                               "Entry Pattern must be a string, list of strings, or Regex"))
 
 (def Entry
   "An authorization entry matching a network or a domain"
-  {:auth-type auth-type
-  :type (schema/enum :domain :opaque :regex :dynamic)
-  :qualifier (schema/enum :exact :inexact)
-  :pattern schema/Any})
+  {:auth-type AuthType
+   :match (schema/enum :string :regex :backreference)
+   :pattern EntryPattern})
 
 (def ACL
   "An ordered list of authorization Entry"
@@ -44,57 +46,58 @@
 
 ;; ACE creation
 
-(defn munge-name
-  [pattern]
-  (-> pattern (str/lower-case) (str/split #"\.") reverse vec))
+(schema/defn ^:private split-domain :- [String]
+  "Given a domain string, split it on '.' and reverse it. For examples,
+  'sylvia.plath.net' becomes ['net' 'plath' 'sylvia']. This is used for domain
+  matching."
+  [pattern :- String]
+  (-> pattern
+      (clojure.string/lower-case)
+      (clojure.string/split #"\.")
+      reverse
+      vec))
 
 (schema/defn new-domain :- Entry
   "Creates a new ACE for a domain"
-  [type :- auth-type
+  [type :- AuthType
    pattern :- schema/Str]
   (cond
     ; global
     (= "*" pattern)
     {:auth-type type
-     :type :regex
-     :qualifier :exact
+     :match :regex
      :pattern #"^*$"}
 
     ; exact domain
     (re-matches #"^(\w[-\w]*\.)+[-\w]+$" pattern)
     {:auth-type type
-     :type :domain
-     :qualifier :exact
-     :pattern (munge-name pattern)}
+     :match :string
+     :pattern (split-domain pattern)}
 
     ; *.domain.com
     (re-matches #"^\*(\.(\w[-\w]*)){1,}$" pattern)
-    (let [host_sans_star (vec (drop-last (munge-name pattern)))]
+    (let [host_sans_star (vec (drop-last (split-domain pattern)))]
       {:auth-type type
-       :type :domain
-       :qualifier :inexact
+       :match :string
        :pattern host_sans_star})
 
     ; backreference
     (re-find #"\$\d+" pattern)
     {:auth-type type
-     :type :dynamic
-     :qualifier :exact
-     :pattern (munge-name pattern)}
+     :match :backreference
+     :pattern (split-domain pattern)}
 
     ; opaque string
     (re-matches #"^\w[-.@\w]*$" pattern)
     {:auth-type type
-     :type :opaque
-     :qualifier :exact
+     :match :string
      :pattern [pattern]}
 
     ; regex
     (re-matches #"^/.*/$" pattern)
     {:auth-type type
-     :type :regex
-     :qualifier :inexact
-     :pattern (str/replace pattern #"^/(.*)/$" "$1")}
+     :match :regex
+     :pattern (clojure.string/replace pattern #"^/(.*)/$" "$1")}
 
     :else
     (throw (Exception. (str "invalid domain pattern: " pattern)))))
@@ -103,29 +106,25 @@
 
 (schema/defn match-name? :- schema/Bool
   "Checks that name matches the given ace"
-  [ace :- Entry
-   name :- schema/Str]
-  (if (= (ace :type) :regex)
-    (boolean (re-find (re-pattern (ace :pattern)) name))
-    (let [name (munge-name name)
-          pattern (ace :pattern)
-          exact (= (ace :qualifier) :exact)]
-      (or (= pattern name)
-          (and (not exact)
-               (every? (fn [[a b]] (= a b)) (map vector pattern name)))))))
+  [{:keys [pattern match]} :- Entry
+   to-match :- schema/Str]
+  (let [match-split-domain (split-domain to-match)]
+    (if (= :regex match)
+      (boolean (re-find (re-pattern pattern) to-match))
+      (every? (fn [[a b]] (= a b)) (map vector pattern match-split-domain)))))
 
 (defn- substitute-backreference
   "substiture $1, $2... by the same index in the captures vector"
   [in captures]
-  (str/replace in #"\$(\d+)" #(nth captures (- (read-string (second %)) 1))))
+  (clojure.string/replace in #"\$(\d+)" #(nth captures (- (read-string (second %)) 1))))
 
 (defn interpolate-backreference
   "change all possible backreferences in ace patterns to values from the
   capture groups"
   [ace captures]
-  (if (= (ace :type) :dynamic)
+  (if (= (:match ace) :backreference)
     (new-domain (ace :auth-type)
-                (str/join "." (map #(substitute-backreference % captures)
+                (clojure.string/join "." (map #(substitute-backreference % captures)
                                    (reverse (ace :pattern)))))
     ace))
 
@@ -139,11 +138,11 @@
 
 (schema/defn add-name :- ACL
   "Add a new host ACE to this acl"
-  ([type :- auth-type
+  ([type :- AuthType
     pattern :- schema/Str]
     (add-name empty-acl type pattern))
   ([acl :- ACL
-    type :- auth-type
+    type :- AuthType
     pattern :- schema/Str]
     (conj acl (new-domain type pattern))))
 

--- a/test/puppetlabs/trapperkeeper/services/authorization/authorization_core_test.clj
+++ b/test/puppetlabs/trapperkeeper/services/authorization/authorization_core_test.clj
@@ -32,14 +32,12 @@
     :pattern   ["com"
                 "guy"
                 "bald"]
-    :qualifier :exact
-    :type      :domain}
+    :match      :string}
    {:auth-type :allow
     :pattern   ["org"
                 "domain"
                 "www"]
-    :qualifier :exact
-    :type      :domain}])
+    :match      :string}])
 
 (deftest valid-configs-pass
   (testing "Valid forms of a auth config pass"
@@ -296,13 +294,9 @@
       (let [m (merge base-path-auth allow-list)
             {:keys [acl]} (config->rule m)]
         (is (= ["org" "domain"] (:pattern (first acl))))
-        (is (= :inexact (:qualifier (first acl))))
-        (is (= ["com" "test"] (:pattern (second acl))))
-        (is (= :inexact (:qualifier (second acl))))))
+        (is (= ["com" "test"] (:pattern (second acl))))))
     (testing "Deny rules with no allow are returned in order"
       (let [m (merge base-path-auth deny-list)
             {:keys [acl]} (config->rule m)]
         (is (= ["com" "eagle" "bald"] (:pattern (first acl))))
-        (is (= :exact (:qualifier (first acl))))
-        (is (= ["com" "bull" "bald"] (:pattern (second acl))))
-        (is (= :exact (:qualifier (first acl))))))))
+        (is (= ["com" "bull" "bald"] (:pattern (second acl))))))))

--- a/test/puppetlabs/trapperkeeper/services/authorization/authorization_core_test.clj
+++ b/test/puppetlabs/trapperkeeper/services/authorization/authorization_core_test.clj
@@ -29,14 +29,12 @@
    Pass the ACL through the vec function when asserting against this
    definition."
   [{:auth-type :deny
-    :length    nil
     :pattern   ["com"
                 "guy"
                 "bald"]
     :qualifier :exact
     :type      :domain}
    {:auth-type :allow
-    :length    nil
     :pattern   ["org"
                 "domain"
                 "www"]


### PR DESCRIPTION
This PR largely cleans up use of schema and removes some dead code.
It mostly deals with the Entry schema but also does some other cleanup.
- Remove  vestigial :length key from Entry
- Removes superfluous :qualifier key from Entry
- Redesigns the :type key as :match in Entry
- Don't require clojure.string as str
- Other minor stuff

I did this because tk-293's implementation was getting hairy so I went
back to master and laid this groundwork to build on.
