### PR TITLE
(TK-293) Implement SSL extension authorization rules

### DIFF
--- a/examples/ring_app/ring-example.conf
+++ b/examples/ring_app/ring-example.conf
@@ -30,6 +30,19 @@ authorization: {
             allow: "$1"
             name: "users allowed by backreference"
             sort-order: 500
-        }
+        },
+        {
+            match-request: {
+                path: "/hello/extension-allowed"
+                type: "path"
+            }
+            allow: {
+                extensions: {
+                    my_extension_shortname: "extensions value"
+                }
+            }
+            name: "Can authorize based on X.509 extensions."
+            sort-order: 500
+        },
     ]
 }

--- a/src/puppetlabs/trapperkeeper/authorization/acl.clj
+++ b/src/puppetlabs/trapperkeeper/authorization/acl.clj
@@ -87,7 +87,7 @@
   [auth-type :- AuthType
    {:keys [certname extensions]} :- ACEConfig]
   (cond
-    ;; CSR Attributes
+    ;; SSL Extensions
     (map? extensions)
     {:auth-type auth-type
      :match :extensions

--- a/src/puppetlabs/trapperkeeper/authorization/acl.clj
+++ b/src/puppetlabs/trapperkeeper/authorization/acl.clj
@@ -3,28 +3,54 @@
 
 ;; Schemas
 
-(def AuthType (schema/enum :allow :deny))
-(def EntryPattern (schema/conditional
-                   string? String
-                   sequential? [String]
-                   :else schema/Regex))
+(def Extensions
+  "Schema for representing SSL Extensions. Maps from a keyword shortname to a
+  string value."
+  {schema/Keyword schema/Str})
 
-(def Entry
+(def ExtensionRule
+  "Schema for defining an SSL Extension auth rule."
+  {schema/Keyword (schema/conditional
+                   sequential? [String]
+                   :else String)})
+
+(def ACEChallenge
+  "Pertinent authorization information extracted from a request used during
+  authz rule enforcement."
+  {:certname String
+   :extensions Extensions})
+
+(def ACEConfig
+  "Schema for representing the configuration of an ACE."
+  (schema/pred #(or (nil? (schema/check String (:certname %)))
+                    (nil? (schema/check ExtensionRule (:extensions %))))
+               "ACE Config Value"))
+
+(def AuthType (schema/enum :allow :deny))
+
+(def ACEValue
+  (schema/conditional
+   map? ExtensionRule
+   string? String
+   sequential? [String]
+   :else schema/Regex))
+
+(def ACE
   "An authorization entry matching a network or a domain"
   {:auth-type AuthType
-   :match (schema/enum :string :regex :backreference)
-   :pattern EntryPattern})
+   :match (schema/enum :string :regex :backreference :extensions)
+   :value ACEValue})
 
 (def ACL
   "An ordered list of authorization Entry"
-  #{Entry})
+  #{ACE})
 
 (schema/defn deny? :- schema/Bool
-  [ace :- Entry]
+  [ace :- ACE]
   (= (ace :auth-type) :deny))
 
 (schema/defn allow? :- schema/Bool
-  [ace :- Entry]
+  [ace :- ACE]
   (= (ace :auth-type) :allow))
 
 ;; ACE comparison
@@ -35,8 +61,8 @@
   For two ACEs of the same type - deny or allow - the 'b' entry always comes
   before the 'a' entry.  When used as a comparator for a sorted set, this
   ensures that entries of the same type are ordered first-in, first-out."
-  [a :- Entry
-   b :- Entry]
+  [a :- ACE
+   b :- ACE]
   (cond
     (deny? b) 1
     (deny? a) -1
@@ -56,123 +82,165 @@
       (clojure.string/split #"\.")
       reverse))
 
-(schema/defn new-domain :- Entry
+(schema/defn ^:always-validate new-domain :- ACE
   "Creates a new ACE for a domain"
-  [type :- AuthType
-   pattern :- schema/Str]
+  [auth-type :- AuthType
+   {:keys [certname extensions]} :- ACEConfig]
   (cond
+    ;; CSR Attributes
+    (map? extensions)
+    {:auth-type auth-type
+     :match :extensions
+     :value extensions}
+
     ; global
-    (= "*" pattern)
-    {:auth-type type
+    (= "*" certname)
+    {:auth-type auth-type
      :match :regex
-     :pattern #"^*$"}
+     :value #"^*$"}
 
     ; exact domain
-    (re-matches #"^(\w[-\w]*\.)+[-\w]+$" pattern)
-    {:auth-type type
+    (re-matches #"^(\w[-\w]*\.)+[-\w]+$" certname)
+    {:auth-type auth-type
      :match :string
-     :pattern (split-domain pattern)}
+     :value (split-domain certname)}
 
     ; *.domain.com
-    (re-matches #"^\*(\.(\w[-\w]*)){1,}$" pattern)
-    (let [host_sans_star (vec (drop-last (split-domain pattern)))]
-      {:auth-type type
+    (re-matches #"^\*(\.(\w[-\w]*)){1,}$" certname)
+    (let [host_sans_star (vec (drop-last (split-domain certname)))]
+      {:auth-type auth-type
        :match :string
-       :pattern host_sans_star})
+       :value host_sans_star})
 
     ; backreference
-    (re-find #"\$\d+" pattern)
-    {:auth-type type
+    (re-find #"\$\d+" certname)
+    {:auth-type auth-type
      :match :backreference
-     :pattern (split-domain pattern)}
+     :value (split-domain certname)}
 
     ; opaque string
-    (re-matches #"^\w[-.@\w]*$" pattern)
-    {:auth-type type
+    (re-matches #"^\w[-.@\w]*$" certname)
+    {:auth-type auth-type
      :match :string
-     :pattern [pattern]}
+     :value [certname]}
 
     ; regex
-    (re-matches #"^/.*/$" pattern)
-    {:auth-type type
+    (re-matches #"^/.*/$" certname)
+    {:auth-type auth-type
      :match :regex
-     :pattern (clojure.string/replace pattern #"^/(.*)/$" "$1")}
+     :value (clojure.string/replace certname #"^/(.*)/$" "$1")}
 
     :else
-    (throw (Exception. (str "invalid domain pattern: " pattern)))))
+    (throw (Exception. (str "invalid domain value: " certname)))))
 
 ;; ACE matching
 
-(schema/defn match-name? :- schema/Bool
+(schema/defn ^:private match-domain? :- schema/Bool
   "Checks that name matches the given ace"
-  [{:keys [pattern match]} :- Entry
+  [{:keys [value match]} :- ACE
    to-match :- schema/Str]
   (let [match-split-domain (split-domain to-match)]
     (if (= :regex match)
-      (boolean (re-find (re-pattern pattern) to-match))
-      (every? (fn [[a b]] (= a b)) (map vector pattern match-split-domain)))))
+      (boolean (re-find (re-pattern value) to-match))
+      (every? (fn [[a b]] (= a b)) (map vector value match-split-domain)))))
 
-(defn- substitute-backreference
+(schema/defn ^:private substitute-backreference :- String
   "substiture $1, $2... by the same index in the captures vector"
-  [in captures]
+  [in :- String
+   captures :- [String]]
   (clojure.string/replace in #"\$(\d+)" #(nth captures (- (read-string (second %)) 1))))
 
-(defn interpolate-backreference
+(schema/defn interpolate-backreference :- ACE
   "change all possible backreferences in ace patterns to values from the
   capture groups"
-  [ace captures]
-  (if (= (:match ace) :backreference)
-    (new-domain (ace :auth-type)
-                (clojure.string/join "." (map #(substitute-backreference % captures)
-                                              (reverse (ace :pattern)))))
+  [{:keys [match auth-type] :as ace} :- ACE
+   captures :- [String]]
+  (if (= match :backreference)
+    (new-domain auth-type
+                {:certname (clojure.string/join "." (map #(substitute-backreference % captures)
+                                                         (reverse (ace :value))))})
     ace))
 
+(schema/defn match-extensions? :- schema/Bool
+  "Returns true if the provided SSL extension map matches the configured ACE.
+  All of the keys in the ACE must appear in the extensions map and, if the value
+  for a key in the ACE is a list, at least one of the listed values must be set
+  in the incoming extensions map.
+
+  Note the behavior in the following scenario: If an ACE specifies
+  {:deny {:extensions {:pp_env 'test'
+                       :pp_image 'bad image'}}}
+
+  *ONLY* a request with both :pp_env set to 'test' and :pp_image set to 'bad
+  image' would be denied. If *any* request with :pp_env set to 'test' is to be
+  denied, it needs a standalone deny rule."
+  [ace :- ACE
+   extensions :- Extensions]
+  (let [match-key (fn [k]
+                    (let [ace-value (get (:value ace) k)
+                          ext-value (get extensions k false)]
+                      (if ext-value
+                        (if (sequential? ace-value)
+                          (some (partial = ext-value) ace-value)
+                          (= ace-value ext-value))
+                        false)))]
+    (every? match-key (keys (:value ace)))))
+
 (schema/defn match? :- schema/Bool
-  "Returns true if the given name matches the given ace"
-  [ace :- Entry
-   name :- schema/Str]
-  (match-name? ace name))
+  "Returns true if the given value matches the given ace"
+  [{:keys [match] :as acl-ace} :- ACE
+   {:keys [certname extensions]} :- ACEChallenge]
+  (cond
+    (= :extensions match)
+    (if (nil? extensions)
+      false
+      (match-extensions? acl-ace extensions))
+
+    :else
+    (if (nil? certname)
+      false
+      (match-domain? acl-ace certname))))
 
 ;; ACL creation
 
-(schema/defn add-name :- ACL
+(schema/defn add-ace :- ACL
   "Add a new host ACE to this acl"
-  ([type :- AuthType
-    pattern :- schema/Str]
-    (add-name empty-acl type pattern))
+  ([auth-type :- AuthType
+    value :- ACEConfig]
+    (add-ace empty-acl auth-type value))
   ([acl :- ACL
-    type :- AuthType
-    pattern :- schema/Str]
-    (conj acl (new-domain type pattern))))
+    auth-type :- AuthType
+    value :- ACEConfig]
+    (conj acl (new-domain auth-type value))))
 
 (schema/defn allow :- ACL
-  "Allow a new pattern to an ACL"
-  ([pattern :- schema/Str]
-    (add-name :allow pattern))
+  "Allow a new value to an ACL"
+  ([value :- ACEConfig]
+    (add-ace :allow value))
   ([acl :- ACL
-   pattern :- schema/Str]
-    (add-name acl :allow pattern)))
+   value :- ACEConfig]
+    (add-ace acl :allow value)))
 
 (schema/defn deny :- ACL
-  "Deny a new pattern to an ACL"
-  ([pattern :- schema/Str]
-    (add-name :deny pattern))
+  "Deny a new value to an ACL"
+  ([value :- ACEConfig]
+    (add-ace :deny value))
   ([acl :- ACL
-    pattern :- schema/Str]
-    (add-name acl :deny pattern)))
+    value :- ACEConfig]
+    (add-ace acl :deny value)))
 
 ;; ACL result
 
 (schema/defn allowed? :- schema/Bool
   "Returns true if the name is allowed by acl, otherwise returns false"
   ([acl :- ACL
-    name :- schema/Str]
-    (allowed? acl name []))
+    incoming-ace :- ACEChallenge]
+    (allowed? acl incoming-ace []))
   ([acl :- ACL
-   name :- schema/Str
-   captures :- [schema/Str]]
-  (let [interpolated-acl (map #(interpolate-backreference % captures) acl)
-        match (some #(if (match? % name) % false) interpolated-acl)]
+    incoming-ace :- ACEChallenge
+    captures :- [schema/Str]]
+   (let [interpolated-acl (map #(interpolate-backreference % captures) acl)
+         match (some #(if (match? % incoming-ace) % false) interpolated-acl)]
       (if match
         (allow? match)
         false))))

--- a/src/puppetlabs/trapperkeeper/authorization/ring.clj
+++ b/src/puppetlabs/trapperkeeper/authorization/ring.clj
@@ -1,5 +1,6 @@
 (ns puppetlabs.trapperkeeper.authorization.ring
-  (:require [schema.core :as schema])
+  (:require [schema.core :as schema]
+            [puppetlabs.trapperkeeper.authorization.acl :as acl])
   (:import (java.security.cert X509Certificate)))
 
 ;; schema
@@ -48,3 +49,15 @@
   [request :- Request
    name :- (schema/maybe schema/Str)]
   (assoc-in request [:authorization :name] (str name)))
+
+(schema/defn set-authorized-extensions :- Request
+  "Set the authorized extensions onto the request."
+  [request :- Request
+   extensions :- acl/Extensions]
+  (assoc-in request [:authorization :extensions] extensions))
+
+(schema/defn authorized-extensions :- acl/Extensions
+  "Get the authorized extensions from the request."
+  [request :- Request]
+  (get-in request [:authorization :extensions] {}))
+

--- a/src/puppetlabs/trapperkeeper/authorization/ring_middleware.clj
+++ b/src/puppetlabs/trapperkeeper/authorization/ring_middleware.clj
@@ -21,7 +21,7 @@
 (def OIDMap
   "Mapping of string OIDs to shortname keywords. Used to update an incoming
   request with a shortname -> value extensions map."
-  {String schema/Keyword})
+  {schema/Str schema/Keyword})
 
 (def header-cert-name
   "Name of the HTTP header through which a client certificate can be passed

--- a/src/puppetlabs/trapperkeeper/services/authorization/authorization_core.clj
+++ b/src/puppetlabs/trapperkeeper/services/authorization/authorization_core.clj
@@ -32,7 +32,7 @@
                (:extensions config-value))))
 
   (when (:certname config-value)
-    (when-not (nil? (schema/check String config-value))
+    (when-not (nil? (schema/check schema/Str config-value))
       (reject! (format "certname key should map to a string; got '%s'" (:certname config-value)))))
 
   (when (or (not (or (:extensions config-value) (:certname config-value)))

--- a/test/puppetlabs/trapperkeeper/authorization/acl_test.clj
+++ b/test/puppetlabs/trapperkeeper/authorization/acl_test.clj
@@ -8,18 +8,18 @@
 
 (deftest test-compare-entry
   (testing "deny before allow"
-    (let [allow-host (acl/new-domain :allow "www.google.com")
-          deny-host (acl/new-domain :deny "www.google.com")]
+    (let [allow-host (acl/new-domain :allow {:certname "www.google.com"})
+          deny-host (acl/new-domain :deny {:certname "www.google.com"})]
       (is (= -1 (acl/ace-compare deny-host allow-host)))
       (is (= 1 (acl/ace-compare allow-host deny-host)))))
   (testing "existing allow before new allow"
-    (let [allow-host-1 (acl/new-domain :allow "www.first.com")
-          allow-host-2 (acl/new-domain :allow "www.second.com")]
+    (let [allow-host-1 (acl/new-domain :allow {:certname "www.first.com"})
+          allow-host-2 (acl/new-domain :allow {:certname "www.second.com"})]
       (is (= 1 (acl/ace-compare allow-host-1 allow-host-2)))
       (is (= 1 (acl/ace-compare allow-host-2 allow-host-1)))))
   (testing "existing deny before new deny"
-    (let [deny-host-1 (acl/new-domain :deny "www.first.com")
-          deny-host-2 (acl/new-domain :deny "www.second.com")]
+    (let [deny-host-1 (acl/new-domain :deny {:certname "www.first.com"})
+          deny-host-2 (acl/new-domain :deny {:certname "www.second.com"})]
       (is (= 1 (acl/ace-compare deny-host-1 deny-host-2)))
       (is (= 1 (acl/ace-compare deny-host-2 deny-host-1))))))
 
@@ -31,9 +31,9 @@
 
 (deftest test-valid-names-ace
   (doseq [name valid-names]
-    (let [acl (acl/new-domain :allow name)]
+    (let [acl (acl/new-domain :allow {:certname name})]
       (testing (str name " match input name")
-        (is (acl/match? acl name))))))
+        (is (acl/match? acl {:certname name :extensions {}}))))))
 
 (def valid-names-wildcard
   [ "abc.12seps.edu.phisher.biz" "www.google.com" "slashdot.org"])
@@ -43,34 +43,35 @@
     (let [name-split (str/split name #"\.")]
       (doseq [i (range 1 (count name-split))]
         (let [host (str/join "." (concat ["*"] (reverse (take i (reverse name-split)))))
-             acl (acl/new-domain :allow host)]
+              acl (acl/new-domain :allow {:certname host})]
           (testing (str host " match input name")
-            (is (acl/match? acl name)))
+            (is (acl/match? acl {:certname name :extensions {}})))
           (testing (str host " doesn't match www.testsite.gov")
-            (is (not (acl/match? acl "www.testsite.gov"))))
+            (is (not (acl/match? acl {:certname "www.testsite.gov" :extensions {}}))))
           (testing (str host " doesn't match hosts that differ in the first non-wildcard segment")
             (let [other-split (str/split name #"\.")
                   pos (- (count other-split) i)
                   other (str/join "." (assoc other-split pos (str "test" (nth other-split pos))))]
-              (is (not (acl/match? acl other))))))))))
+              (is (not (acl/match? acl {:certname other :extensions {}}))))))))))
 
 (deftest test-fqdn
   (testing "match a similar PQDN"
-    (is (not (acl/match? (acl/new-domain :allow "spirit.mars.nasa.gov.") "spirit.mars.nasa.gov")))))
+    (is (not (acl/match? (acl/new-domain :allow {:certname "spirit.mars.nasa.gov."}) {:certname "spirit.mars.nasa.gov"
+                                                                                      :extensions {}})))))
 
 (deftest test-regex
-  (let [acl (acl/new-domain :allow "/^(test-)?host[0-9]+\\.other-domain\\.(com|org|net)$|some-domain\\.com/")]
+  (let [acl (acl/new-domain :allow {:certname "/^(test-)?host[0-9]+\\.other-domain\\.(com|org|net)$|some-domain\\.com/"})]
     (doseq [host ["host5.other-domain.com" "test-host12.other-domain.net" "foo.some-domain.com"]]
       (testing (str host "match regex")
-        (is (acl/match? acl host))))
+        (is (acl/match? acl {:certname host :extensions {}}))))
     (doseq [host ["'host0.some-other-domain.com" ""]]
       (testing (str host " doesn't match regex")
-        (is (not (acl/match? acl host)))))))
+        (is (not (acl/match? acl {:certname host :extensions {}})))))))
 
 (deftest test-backreference-interpolation
   (testing "injecting backreference values"
-    (let [acl (acl/new-domain :allow "$1.$2.domain.com")]
-      (is (= (:pattern (acl/interpolate-backreference acl ["a" "b"])) ["com" "domain" "b" "a"])))))
+    (let [acl (acl/new-domain :allow {:certname "$1.$2.domain.com"})]
+      (is (= (:value (acl/interpolate-backreference acl ["a" "b"])) ["com" "domain" "b" "a"])))))
 
 (deftest test-empty-acl
   (testing "it is empty"
@@ -78,57 +79,122 @@
 
 (deftest test-acl-creation
   (testing "not empty when allowing a domain"
-    (is (not= 0 (count (acl/allow "www.google.com")))))
+    (is (not= 0 (count (acl/allow {:certname "www.google.com"})))))
   (testing "not empty when denying a domain"
-    (is (not= 0 (count (acl/deny "www.google.com"))))))
+    (is (not= 0 (count (acl/deny {:certname "www.google.com"}))))))
 
 (deftest test-acl-ordering
   (testing "deny ACEs ordered before allow ACEs"
-    (let [expected-acl [(acl/new-domain :deny "*.domain.com")
-                        (acl/new-domain :deny "my.domain.com")
-                        (acl/new-domain :allow "*.domain.com")
-                        (acl/new-domain :allow "my.domain.com")]]
+    (let [expected-acl [(acl/new-domain :deny {:certname "*.domain.com"})
+                        (acl/new-domain :deny {:certname "my.domain.com"})
+                        (acl/new-domain :allow {:certname "*.domain.com"})
+                        (acl/new-domain :allow {:certname "my.domain.com"})]]
       (testing "when allow ACEs added first"
-        (is (= expected-acl (-> (acl/allow "*.domain.com")
-                                (acl/allow "my.domain.com")
-                                (acl/deny "*.domain.com")
-                                (acl/deny "my.domain.com")
+        (is (= expected-acl (-> (acl/allow {:certname "*.domain.com"})
+                                (acl/allow {:certname "my.domain.com"})
+                                (acl/deny {:certname "*.domain.com"})
+                                (acl/deny {:certname "my.domain.com"})
                                 vec))))
       (testing "when deny ACEs added first"
-        (is (= expected-acl (-> (acl/deny "*.domain.com")
-                                (acl/deny "my.domain.com")
-                                (acl/allow "*.domain.com")
-                                (acl/allow "my.domain.com")
+        (is (= expected-acl (-> (acl/deny {:certname "*.domain.com"})
+                                (acl/deny {:certname "my.domain.com"})
+                                (acl/allow {:certname "*.domain.com"})
+                                (acl/allow {:certname "my.domain.com"})
                                 vec))))
       (testing "when ACEs added in mixed order"
-        (is (= expected-acl (-> (acl/allow "*.domain.com")
-                                (acl/deny "*.domain.com")
-                                (acl/deny "my.domain.com")
-                                (acl/allow "my.domain.com")
+        (is (= expected-acl (-> (acl/allow {:certname "*.domain.com"})
+                                (acl/deny {:certname "*.domain.com"})
+                                (acl/deny {:certname "my.domain.com"})
+                                (acl/allow {:certname "my.domain.com"})
                                 vec)))))))
 
-(deftest test-acl-matching
-  (let [acl (-> (acl/allow "*.domain.com")
-                (acl/deny "*.test.org"))]
+(deftest test-acl-certname-matching
+  (let [acl (-> (acl/allow {:certname "*.domain.com"})
+                (acl/deny {:certname "*.test.org"}))]
     (testing "allowing by name"
-      (is (acl/allowed? acl "test.domain.com")))
+      (is (acl/allowed? acl {:certname "test.domain.com" :extensions {}})))
     (testing "denying by name"
-      (is (not (acl/allowed? acl "www.test.org"))))
+      (is (not (acl/allowed? acl {:certname "www.test.org" :extensions {}}))))
     (testing "no match is deny"
-      (is (not (acl/allowed? acl "www.google.com"))))))
+      (is (not (acl/allowed? acl {:certname "www.google.com" :extensions {}}))))))
 
 (deftest test-global-allow
-  (let [acl (acl/allow "*")]
+  (let [acl (acl/allow {:certname "*"})]
     (testing "should allow anything"
-      (is (acl/allowed? acl "anything")))))
+      (is (acl/allowed? acl {:certname "anything" :extensions {}})))))
 
-(deftest test-acl-matching-with-captures
+(deftest test-acl-certname-matching-with-captures
   (testing "matching backreference of simple name"
-    (let [acl (acl/allow "$1.google.com")]
-      (is (acl/allowed? acl "www.google.com" ["www"]))))
+    (let [acl (acl/allow {:certname "$1.google.com"})]
+      (is (acl/allowed? acl {:certname "www.google.com" :extensions {}} ["www"]))))
   (testing "matching backreference of opaque name"
-    (let [acl (acl/allow "$1")]
-      (is (acl/allowed? acl "c216f41a-f902-4bfb-a222-850dd957bebb" ["c216f41a-f902-4bfb-a222-850dd957bebb"]))))
+    (let [acl (acl/allow {:certname "$1"})]
+      (is (acl/allowed? acl {:certname "c216f41a-f902-4bfb-a222-850dd957bebb"
+                             :extensions {}}
+                        ["c216f41a-f902-4bfb-a222-850dd957bebb"]))))
   (testing "matching backreference of name"
-    (let [acl (acl/allow "$1")]
-      (is (acl/allowed? acl "admin.mgmt.nym1" ["admin.mgmt.nym1"])))))
+    (let [acl (acl/allow {:certname "$1"})]
+      (is (acl/allowed? acl {:certname "admin.mgmt.nym1"
+                             :extensions {}}
+                        ["admin.mgmt.nym1"])))))
+
+(defn challenge
+  ([extensions]
+   (challenge "sylvia.plath.net" extensions))
+  ([certname extensions]
+   (let [default-extensions {:foo "foo"
+                             :baz "baz"
+                             :quux "quux"}]
+     {:certname certname
+      :extensions (merge default-extensions extensions)})))
+
+(deftest test-extension-matching
+  (testing "when using extensions in an ACL"
+    (testing "with scalar matching"
+      (let [allowed? (partial acl/allowed? (acl/allow {:extensions {:tradition "confessional"
+                                                                    :author "plath"}}))
+            !allowed? (comp not allowed?)]
+        (is (allowed? (challenge {:tradition "confessional" :author "plath"})))
+        (is (!allowed? (challenge {:tradition "surrealist" :author "plath"})))
+        (is (!allowed? (challenge {:tradition "surrealist" :author "burroughs"})))
+        (is (!allowed? (challenge {})))
+        (is (!allowed? (challenge {:style "cutup" :publisher "knopf"})))))
+
+    (testing "with list matching"
+      (let [allowed? (partial acl/allowed?
+                              (acl/allow {:extensions {:style ["sonnet" "prose" "sestina"]
+                                                       :author "olds"}}))
+            !allowed? (comp not allowed?)]
+        (is (allowed? (challenge {:style "prose" :author "olds"})))
+        (is (allowed? (challenge {:style "sestina" :author "olds"})))
+        (is (allowed? (challenge {:style "sonnet" :author "olds"})))
+        (is (!allowed? (challenge {:style "haiku" :author "olds"})))
+        (is (!allowed? (challenge {:style "sestina" :author "burroughs"})))))
+    (testing "with a varied ACL"
+      (let [allowed? (partial acl/allowed?
+                              (-> (acl/allow {:extensions {:style ["sonnet" "prose" "sestina"]}})
+                                  (acl/allow {:certname "new.confessional.org"})
+                                  (acl/deny {:extensions {:length "epic"}})
+                                  (acl/deny {:extensions {:length "epic"
+                                                          :style "formalist"}})
+                                  (acl/deny {:extensions {:style "slam"}})
+                                  (acl/deny {:certname "neo.formalism.com"})
+                                  (acl/deny {:extensions {:author "gioia"}})
+                                  (acl/allow {:extensions {:style "haiku"
+                                                           :author "plath"}})))
+            !allowed? (comp not allowed?)]
+        (is (allowed? (challenge "new.confessional.org" {:style "sonnet"})))
+        (is (allowed? (challenge "new.confessional.org"
+                                 {:style "haiku" :author "plath"})))
+        (is (allowed? (challenge {:style "prose"})))
+        (is (allowed? (challenge {:style "sestina" :author "plath"})))
+        (is (allowed? (challenge "new.confessional.org" {})))
+        (is (allowed? (challenge "whatever.com" {:length "short" :style "prose"})))
+        (is (!allowed? (challenge "new.confessional.org" {:length "epic" :style "haiku"})))
+        (is (!allowed? (challenge "whatever.com" {:length "short" :style "cut up"})))
+        (is (!allowed? (challenge "new.confessional.org" {:style "haiku"
+                                                          :length "epic"
+                                                          :author "plath"})))
+        (is (!allowed? (challenge "new.confessional.org" {:style "slam" :author "plath"})))
+        (is (!allowed? (challenge "new.confessional.org" {:style "sonnet" :author "gioia"})))
+        (is (!allowed? (challenge "neo.formalism.com" {:style "haiku" :author "plath"})))))))

--- a/test/puppetlabs/trapperkeeper/authorization/testutils.clj
+++ b/test/puppetlabs/trapperkeeper/authorization/testutils.clj
@@ -20,9 +20,13 @@
    (assoc (request path method ip) :ssl-client-cert certificate)))
 
 (defn create-certificate
-  [cn]
-  (let [cacert (ssl/gen-self-signed-cert "my ca" 41 {:keylength 512})]
-    (:cert (ssl/gen-cert cn cacert 42 {:keylength 512}))))
+  [cn & [extensions]]
+  (let [cacert (ssl/gen-self-signed-cert "my ca" 41 {:keylength 512})
+        opts {:keylength 512}
+        opts (if (nil? extensions)
+               opts
+               (assoc opts :extensions extensions))]
+    (:cert (ssl/gen-cert cn cacert 42 opts))))
 
 (def test-domain-cert (create-certificate "test.domain.org"))
 (def test-other-cert (create-certificate "www.other.org"))

--- a/test/puppetlabs/trapperkeeper/services/authorization/authorization_core_test.clj
+++ b/test/puppetlabs/trapperkeeper/services/authorization/authorization_core_test.clj
@@ -29,12 +29,12 @@
    Pass the ACL through the vec function when asserting against this
    definition."
   [{:auth-type :deny
-    :pattern   ["com"
+    :value   ["com"
                 "guy"
                 "bald"]
     :match      :string}
    {:auth-type :allow
-    :pattern   ["org"
+    :value   ["org"
                 "domain"
                 "www"]
     :match      :string}])
@@ -162,7 +162,7 @@
 
     (is (thrown-with-msg?
           IllegalArgumentException
-          #".* contains one or more names that are not strings."
+          #".* contains one or more aces that are not maps or strings."
           (validate-auth-config-rule! (assoc testrule :deny ["one.anem" 23]))))
 
     (is (thrown-with-msg?
@@ -293,10 +293,10 @@
     (testing "Allow rules with no deny are returned in order"
       (let [m (merge base-path-auth allow-list)
             {:keys [acl]} (config->rule m)]
-        (is (= ["org" "domain"] (:pattern (first acl))))
-        (is (= ["com" "test"] (:pattern (second acl))))))
+        (is (= ["org" "domain"] (:value (first acl))))
+        (is (= ["com" "test"] (:value (second acl))))))
     (testing "Deny rules with no allow are returned in order"
       (let [m (merge base-path-auth deny-list)
             {:keys [acl]} (config->rule m)]
-        (is (= ["com" "eagle" "bald"] (:pattern (first acl))))
-        (is (= ["com" "bull" "bald"] (:pattern (second acl))))))))
+        (is (= ["com" "eagle" "bald"] (:value (first acl))))
+        (is (= ["com" "bull" "bald"] (:value (second acl))))))))


### PR DESCRIPTION
This PR adds support for a new feature: The ability to write
authorization rules based on SSL Extensions (also known as CSR
Attributes).

This entails:
- Updating test utils to generate certs with extensions signed in more easily
- Some code cleanup
- Updating the configuration syntax to take a data structure instead of
  just string certnames when setting allow/deny values
- Configurable translation from OID -> short name when extracting
  extensions from certificates
- Updating the authorization enforcement code to match on either
  certname or extensions
- General refactoring to support a map where we used to only support a
  string.
- Updating tests to handle the new match data structure
- A flurry of new schemas

This only implements basic string matching for SSL extensions. In other words, extensions that are more complex than key -> value are not currently supported. You can, however, specify a list of valid extension values to match against.
