### PR TITLE
(maint) Check schema of just the certname

### DIFF
--- a/src/puppetlabs/trapperkeeper/services/authorization/authorization_core.clj
+++ b/src/puppetlabs/trapperkeeper/services/authorization/authorization_core.clj
@@ -142,9 +142,16 @@
         get-br-list (fn [match-str]
                       (map #(Integer/parseInt (second %))
                            (re-seq #"\$(\d+)" match-str)))
+        get-certname-list (fn [rule]
+                            (cond
+                              (string? rule) (list rule)
+                              (map? rule) (list (get rule :certname ""))
+                              (seq? rule) (for [x rule]
+                                                 (if (map? x) (get x :certname "") x))
+                              :else (list "")))
         largest-br (fn [match]
                      (let [br-list (mapcat get-br-list
-                                           (flatten [(or match "")]))]
+                                           (get-certname-list match))]
                        (when (> (count br-list) 0)
                          (apply max br-list))))
         largest-allow-br (or (largest-br (:allow rule)) 0)

--- a/src/puppetlabs/trapperkeeper/services/authorization/authorization_core.clj
+++ b/src/puppetlabs/trapperkeeper/services/authorization/authorization_core.clj
@@ -32,7 +32,7 @@
                (:extensions config-value))))
 
   (when (:certname config-value)
-    (when-not (nil? (schema/check schema/Str config-value))
+    (when-not (nil? (schema/check schema/Str (:certname config-value)))
       (reject! (format "certname key should map to a string; got '%s'" (:certname config-value)))))
 
   (when (or (not (or (:extensions config-value) (:certname config-value)))

--- a/src/puppetlabs/trapperkeeper/services/authorization/authorization_core.clj
+++ b/src/puppetlabs/trapperkeeper/services/authorization/authorization_core.clj
@@ -146,7 +146,7 @@
                             (cond
                               (string? rule) (list rule)
                               (map? rule) (list (get rule :certname ""))
-                              (seq? rule) (for [x rule]
+                              (sequential? rule) (for [x rule]
                                                  (if (map? x) (get x :certname "") x))
                               :else (list "")))
         largest-br (fn [match]

--- a/test/puppetlabs/trapperkeeper/services/authorization/authorization_core_test.clj
+++ b/test/puppetlabs/trapperkeeper/services/authorization/authorization_core_test.clj
@@ -13,8 +13,12 @@
                       :sort-order 500 :name "base-regex-auth"})
 (def allow-single {:allow "www.domain.org"})
 (def allow-list {:allow ["*.domain.org" "*.test.com"]})
+(def allow-list-of-maps {:allow ["foo.bar.com", {:extensions {:foo "bar"}}]})
+(def allow-map {:allow {:certname "bald.fish.com"}})
 (def deny-single {:deny "bald.guy.com"})
 (def deny-list {:deny ["bald.eagle.com" "bald.bull.com"]})
+(def deny-map {:deny {:extensions {:thing "bald.wolf.com"}}})
+(def deny-list-of-maps {:deny ["foo.bar.com", {:certname "bar.nate.wolfe"}]})
 (def single-query-param {:match-request {:query-params {:environment "production"}}})
 (def multi-query-param {:match-request {:query-params {:env ["prod" "staging"]}}})
 (def allow-unauthenticated {:allow-unauthenticated true})
@@ -42,8 +46,8 @@
 (deftest valid-configs-pass
   (testing "Valid forms of a auth config pass"
     (doseq [base [base-path-auth base-regex-auth]
-            allow [allow-list allow-single nil]
-            deny [deny-list deny-single nil]
+            allow [allow-list allow-single allow-map allow-list-of-maps nil]
+            deny [deny-list deny-single deny-map deny-list-of-maps nil]
             methods [{} method-get method-put multiple-methods]
             params [single-query-param multi-query-param]]
       (let [rule (merge-with merge base allow deny params methods)]

--- a/test/puppetlabs/trapperkeeper/services/authorization/authorization_core_test.clj
+++ b/test/puppetlabs/trapperkeeper/services/authorization/authorization_core_test.clj
@@ -226,6 +226,15 @@
              :name "base-regex-auth"})))
 
     (is (thrown-with-msg?
+         IllegalArgumentException
+         #"contains the back reference '\$1' which refers to a capture group in the regex that doesn't exist."
+         (validate-auth-config-rule!
+          {:match-request {:path "/some/thing" :type "regex"}
+           :allow {:certname "$1"}
+           :sort-order 500
+           :name "base-regex-auth"})))
+
+    (is (thrown-with-msg?
           IllegalArgumentException
           #"contains the back reference '\$2' which refers to a capture group in the regex that doesn't exist."
           (validate-auth-config-rule!
@@ -233,6 +242,15 @@
              :allow "$1$2"
              :sort-order 500
              :name "base-regex-auth"})))
+
+    (is (thrown-with-msg?
+         IllegalArgumentException
+         #"contains the back reference '\$2' which refers to a capture group in the regex that doesn't exist."
+         (validate-auth-config-rule!
+          {:match-request {:path "/some/(thing)" :type "regex"}
+           :allow ["foo" {:certname "$1$2"}]
+           :sort-order 500
+           :name "base-regex-auth"})))
 
     (is (thrown-with-msg?
           IllegalArgumentException


### PR DESCRIPTION
Previously the schema check for an ace-config entry would attempt to
validate that a map and not the value in the map was a string. As a map
is never a string, trying to use a certname entry in an allow/deny map
would not work. This commit corrects that to use the value and not the
map itself.
