### PR TITLE
Consolidate common middleware and helpers

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,5 +1,5 @@
-(def ks-version "1.0.0")
-(def tk-version "1.1.1")
+(def ks-version "1.3.0")
+(def tk-version "1.4.0")
 (def tk-jetty-version "1.4.1")
 
 (defproject puppetlabs/trapperkeeper-authorization "0.5.1-SNAPSHOT"
@@ -13,21 +13,28 @@
   ;; requires lein 2.2.0+.
   :pedantic? :abort
 
+  :exclusions [org.clojure/clojure]
   :dependencies [[org.clojure/clojure "1.6.0"]
-                 [org.clojure/tools.logging "0.2.6"]
-                 [org.clojure/tools.cli "0.3.0"]
-                 [me.raynes/fs "1.4.5"]
-                 [prismatic/schema "0.4.0"]
+                 [org.clojure/tools.logging "0.3.1"]
+                 [org.clojure/tools.cli "0.3.4"]
+                 [me.raynes/fs "1.4.6"]
+                 [prismatic/schema "1.1.1"]
                  [ring/ring-core "1.4.0"]
-                 [ring/ring-mock "0.2.0"]
+                 [ring/ring-mock "0.3.0"]
 
                  ;; begin version conflict resolution dependencies
-                 [clj-time "0.10.0"]
+                 [clj-time "0.11.0"]
+                 [ring/ring-servlet "1.4.0"]
+                 [slingshot "0.12.2"]
+                 [cheshire "5.6.1"]
+                 [org.slf4j/slf4j-api "1.7.13"]
+                 [org.clojure/tools.reader "1.0.0-alpha1"]
                  ;; end version conflict resolution dependencies
 
                  [puppetlabs/kitchensink ~ks-version]
                  [puppetlabs/trapperkeeper ~tk-version]
-                 [puppetlabs/typesafe-config "0.1.4"]
+                 [puppetlabs/ring-middleware "0.3.0"]
+                 [puppetlabs/typesafe-config "0.1.5"]
                  [puppetlabs/ssl-utils "0.8.1"]]
 
   ;; By declaring a classifier here and a corresponding profile below we'll get an additional jar

--- a/project.clj
+++ b/project.clj
@@ -13,8 +13,7 @@
   ;; requires lein 2.2.0+.
   :pedantic? :abort
 
-  :exclusions [org.clojure/clojure]
-  :dependencies [[org.clojure/clojure "1.6.0"]
+  :dependencies [[org.clojure/clojure "1.7.0"]
                  [org.clojure/tools.logging "0.3.1"]
                  [org.clojure/tools.cli "0.3.4"]
                  [me.raynes/fs "1.4.6"]

--- a/src/puppetlabs/trapperkeeper/services/authorization/authorization_service.clj
+++ b/src/puppetlabs/trapperkeeper/services/authorization/authorization_service.clj
@@ -1,5 +1,6 @@
 (ns puppetlabs.trapperkeeper.services.authorization.authorization-service
   (:require [clojure.tools.logging :as log]
+            [puppetlabs.ring-middleware.core :as mw]
             [puppetlabs.trapperkeeper.authorization.ring-middleware :as
              ring-middleware]
             [puppetlabs.trapperkeeper.core :refer [defservice]]
@@ -41,4 +42,4 @@
    (let [{:keys [allow-header-cert-info rules]} (service-context this)]
      (-> handler
          (ring-middleware/wrap-authorization-check rules oid-map allow-header-cert-info)
-         ring-middleware/wrap-with-error-handling))))
+         (mw/wrap-bad-request :plain)))))

--- a/test/puppetlabs/trapperkeeper/authorization/ring_middleware_test.clj
+++ b/test/puppetlabs/trapperkeeper/authorization/ring_middleware_test.clj
@@ -127,18 +127,18 @@
                 (cert-from-request (testutils/url-encoded-cert
                                     testutils/test-domain-cert))))))
       (testing "fails as expected when cert not properly URL encoded"
-        (is (thrown+? [:type :puppetlabs.trapperkeeper.authorization.ring-middleware/bad-request
+        (is (thrown+? [:type :bad-request
                        :message (str "Unable to URL decode the x-client-cert header: "
                                      "For input string: \"1%\"")]
                       (cert-from-request "%1%2"))))
       (testing "fails as expected when URL encoded properly but base64 content malformed"
-        (is (thrown+? [:type :puppetlabs.trapperkeeper.authorization.ring-middleware/bad-request
+        (is (thrown+? [:type :bad-request
                        :message (str "Unable to parse x-client-cert into "
                                      "certificate: -----END CERTIFICATE not found")]
                       (cert-from-request
                        "-----BEGIN%20CERTIFICATE-----%0AM"))))
       (testing "fails when cert not in the payload"
-        (is (thrown+? [:type :puppetlabs.trapperkeeper.authorization.ring-middleware/bad-request
+        (is (thrown+? [:type :bad-request
                        :message "No certs found in PEM read from x-client-cert"]
                       (cert-from-request "NOCERTSHERE"))))
       (testing "fails when more than one cert is in the payload"
@@ -146,7 +146,7 @@
               _ (ssl-utils/cert->pem! testutils/test-domain-cert cert-writer)
               _ (ssl-utils/cert->pem! testutils/test-domain-cert cert-writer)
               certs-encoded (ring-codec/url-encode cert-writer)]
-          (is (thrown+? [:type :puppetlabs.trapperkeeper.authorization.ring-middleware/bad-request
+          (is (thrown+? [:type :bad-request
                          :message (str "Only 1 PEM should be supplied for "
                                        "x-client-cert but 2 found")]
                         (cert-from-request certs-encoded))))))))

--- a/test/puppetlabs/trapperkeeper/services/authorization/authorization_service_test.clj
+++ b/test/puppetlabs/trapperkeeper/services/authorization/authorization_service_test.clj
@@ -288,9 +288,10 @@
                   (assoc :uri "/puppet/v3/environments")
                   (assoc :body "Hello World!")
                   (update-in [:headers] assoc "x-client-cert" "NOCERTS"))
-          {:keys [status body]} (app req)]
+          {:keys [status body headers]} (app req)]
       (is (= status 400))
-      (is (re-matches #".*No certs found in PEM read from x-client-cert.*" body)))))
+      (is (re-matches #".*No certs found in PEM read from x-client-cert.*" body))
+      (is (re-matches #"text/plain.*" (headers "Content-Type"))))))
 
 (deftest ^:integration query-params-test
   (let [app (build-ring-handler

--- a/test/puppetlabs/trapperkeeper/services/authorization/authorization_service_test.clj
+++ b/test/puppetlabs/trapperkeeper/services/authorization/authorization_service_test.clj
@@ -290,7 +290,7 @@
                   (update-in [:headers] assoc "x-client-cert" "NOCERTS"))
           {:keys [status body]} (app req)]
       (is (= status 400))
-      (is (= body "No certs found in PEM read from x-client-cert")))))
+      (is (re-matches #".*No certs found in PEM read from x-client-cert.*" body)))))
 
 (deftest ^:integration query-params-test
   (let [app (build-ring-handler

--- a/test/puppetlabs/trapperkeeper/services/authorization/authorization_service_test.clj
+++ b/test/puppetlabs/trapperkeeper/services/authorization/authorization_service_test.clj
@@ -290,8 +290,7 @@
                   (update-in [:headers] assoc "x-client-cert" "NOCERTS"))
           {:keys [status body headers]} (app req)]
       (is (= status 400))
-      (is (re-matches #".*No certs found in PEM read from x-client-cert.*" body))
-      (is (re-matches #"text/plain.*" (headers "Content-Type"))))))
+      (is (= "No certs found in PEM read from x-client-cert" body)))))
 
 (deftest ^:integration query-params-test
   (let [app (build-ring-handler


### PR DESCRIPTION
As part of TK-214, we extended the middleware and middleware helpers in
the shared library ring-middleware.

This refactors tk-auth to use the bad-request helpers and invalid data
middleware.
