### PR TITLE
(TK-360) Remove IP address from responses to forbidden reqs

### DIFF
--- a/src/puppetlabs/trapperkeeper/authorization/rules.clj
+++ b/src/puppetlabs/trapperkeeper/authorization/rules.clj
@@ -144,7 +144,7 @@
        "Request to '%s' from '%s' did not match rule '%s' - continuing matching"
        (:uri request) (requestor request) (:name rule)))))
 
-(defn- request->description
+(defn- request->log-description
   [request rule]
   (let [from (requestor request)
         path (:uri request)
@@ -154,6 +154,13 @@
          (if-let [file (:file rule)] (str " at " file ":" (:line rule)))
          (format " (authenticated: %s) " authenticated?)
          (format "denied by rule '%s'." (:name rule)))))
+
+(defn- request->resp-description
+  [request rule]
+  (let [path (:uri request)
+        method (:request-method request)]
+    (str "Forbidden request: " path " (method " method "). "
+         "Please see the server logs for details.")))
 
 (schema/defn allow-request :- AuthorizationResult
   "Logs debugging information about the request and rule at the TRACE level
@@ -172,20 +179,25 @@
   "Logs debugging information about the request and rule at the TRACE level
    as well as the reason for denial at the ERROR level, and returns an
    unauthorized authorization result with the provided reason message."
-  [request :- ring/Request
-   rule :- (schema/maybe Rule)
-   reason :- schema/Str]
-  (if rule
-    (log/tracef
-     "Request to '%s' from '%s' handled by rule '%s' - request denied"
-     (:uri request) (requestor request) (:name rule))
-    (log/tracef
-     "Request to '%s' from '%s' did not match any rules - request denied"
-     (:uri request) (requestor request)))
-  (log/error reason)
-  {:authorized false
-   :message reason
-   :request request})
+  ([request
+    rule
+    reason]
+   (deny-request request rule reason reason))
+  ([request :- ring/Request
+    rule :- (schema/maybe Rule)
+    log-reason :- schema/Str
+    resp-reason :- schema/Str]
+   (if rule
+     (log/tracef
+      "Request to '%s' from '%s' handled by rule '%s' - request denied"
+      (:uri request) (requestor request) (:name rule))
+     (log/tracef
+      "Request to '%s' from '%s' did not match any rules - request denied"
+      (:uri request) (requestor request)))
+   (log/error log-reason)
+   {:authorized false
+    :message resp-reason
+    :request request}))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Rules checking
@@ -201,7 +213,8 @@
       (if (and (true? (ring/authorized-authenticated request))
                (acl/allowed? (:acl rule) (ring/authorized-name request) matches))
         (allow-request request rule "")
-        (deny-request request rule (request->description request rule))))
+        (deny-request request rule (request->log-description request rule)
+                      (request->resp-description request rule))))
     (deny-request request nil "global deny all - no rules matched")))
 
 (schema/defn authorized? :- schema/Bool

--- a/test/puppetlabs/trapperkeeper/authorization/ring_middleware_test.clj
+++ b/test/puppetlabs/trapperkeeper/authorization/ring_middleware_test.clj
@@ -177,9 +177,8 @@
                                        :get "127.0.0.1"
                                        testutils/test-other-cert))]
            (is (= 403 (:status response)))
-           (is (= (str "Forbidden request: www.other.org(127.0.0.1) access to "
-                       "/path/to/foo (method :get) (authenticated: true) denied by "
-                       "rule 'test rule'.")
+           (is (= (str "Forbidden request: /path/to/foo (method :get)."
+                       " Please see the server logs for details.")
                   (:body response)))))
        (testing "access denied when cert CN is explicitly denied in the rule"
          (let [response (ring-handler (testutils/request
@@ -187,10 +186,8 @@
                                        :get "127.0.0.1"
                                        testutils/test-denied-cert))]
            (is (= 403 (:status response)))
-           (is (= (str "Forbidden request: bad.guy.com(127.0.0.1) access to "
-                       "/path/to/foo (method :get) (authenticated: true) denied by "
-                       "rule 'test rule'.")
-                  (:body response))))))
+            (is  = (str "Forbidden request: /path/to/foo (method :get)."
+                       " Please see the server logs for details.")))))
      (testing "access denied when deny all"
        (let [app (build-ring-handler [(-> (testutils/new-rule :path "/")
                                           (rules/deny "*"))]
@@ -220,9 +217,8 @@
                                           (wrap-successful-x-client-cn
                                            "www.other.org")))]
            (is (= 403 (:status response)))
-           (is (= (str "Forbidden request: www.other.org(127.0.0.1) access to "
-                       "/path/to/foo (method :get) (authenticated: true) denied by "
-                       "rule 'test rule'.")
+           (is (= (str "Forbidden request: /path/to/foo (method :get)."
+                       " Please see the server logs for details.")
                   (:body response)))))
        (testing "access denied when cert CN is explicitly denied in the rule"
          (let [response (ring-handler (-> (testutils/request
@@ -231,9 +227,8 @@
                                           (wrap-successful-x-client-cn
                                            "bad.guy.com")))]
            (is (= 403 (:status response)))
-           (is (= (str "Forbidden request: bad.guy.com(127.0.0.1) access to "
-                       "/path/to/foo (method :get) (authenticated: true) denied by "
-                       "rule 'test rule'.")
+           (is (= (str "Forbidden request: /path/to/foo (method :get)."
+                       " Please see the server logs for details.")
                   (:body response))))))
      (testing "access denied when deny all"
        (let [app (build-ring-handler [(-> (testutils/new-rule :path "/")

--- a/test/puppetlabs/trapperkeeper/authorization/rules_test.clj
+++ b/test/puppetlabs/trapperkeeper/authorization/rules_test.clj
@@ -142,22 +142,28 @@
       (testing "rule not allowing"
         (let [rules (build-rules ["/path/to/resource" "*.domain.org"]
                                  ["/stairway/to/heaven" "*.domain.org"])
-              request (ring/set-authorized-name request "www.test.org")]
-          (is (not (rules/authorized? (rules/allowed? rules request))))
-          (is (= (:message (rules/allowed? rules request))
-                 (str "Forbidden request: www.test.org(192.168.1.23) access to "
-                      "/stairway/to/heaven (method :get) (authenticated: true) "
-                      "denied by rule 'test rule'.")))))
+              request (ring/set-authorized-name request "www.test.org")
+              rules-allowed (rules/allowed? rules request)]
+          (is (not (rules/authorized? rules-allowed )))
+          (is (= (:message rules-allowed)
+                 (str "Forbidden request: /stairway/to/heaven (method :get)."
+                      " Please see the server logs for details.")))
+          ;; TODO: this and the test below are ridiculously long.
+          ;; Unfortunately, there does not seem to be a good way to improve
+          ;; these until we can upgrade TK versions and use a newer version of
+          ;; the logging testutils.
+          (is (logged? #"Forbidden request: www.test.org\(192.168.1.23\) access to /stairway/to/heaven \(method :get\) \(authenticated: true\) denied by rule 'test rule'." :error))))
       (testing "tagged rule not allowing "
         (let [rules (map #(rules/tag-rule %1 "file.txt" 23)
                          (build-rules ["/path/to/resource" "*.domain.org"]
                                       ["/stairway/to/heaven" "*.domain.org"]))
-              request (ring/set-authorized-name request "www.test.org")]
-          (is (not (rules/authorized? (rules/allowed? rules request))))
-          (is (= (:message (rules/allowed? rules request))
-                 (str "Forbidden request: www.test.org(192.168.1.23) access to "
-                      "/stairway/to/heaven (method :get) at file.txt:23 "
-                      "(authenticated: true) denied by rule 'test rule'."))))))))
+              request (ring/set-authorized-name request "www.test.org")
+              rules-allowed (rules/allowed? rules request)]
+          (is (not (rules/authorized? rules-allowed)))
+          (is (= (:message rules-allowed)
+                 (str "Forbidden request: /stairway/to/heaven (method :get)."
+                      " Please see the server logs for details.")))
+          (is (logged? #"Forbidden request: www.test.org\(192.168.1.23\) access to /stairway/to/heaven \(method :get\) at file.txt:23 \(authenticated: true\) denied by rule 'test rule'.")))))))
 
 (deftest test-rule-sorting
   (testing "rules checked in order of sort-order not order of appearance"

--- a/test/puppetlabs/trapperkeeper/services/authorization/authorization_service_test.clj
+++ b/test/puppetlabs/trapperkeeper/services/authorization/authorization_service_test.clj
@@ -223,10 +223,8 @@
           req (assoc catalog-request-nocert :body "Hello World!")
           {:keys [status body]} (app req)]
       (is (= status 403))
-      (is (= body (str "Forbidden request: 127.0.0.1 "
-                       "access to /puppet/v3/catalog/localhost "
-                       "(method :get) (authenticated: false) "
-                       "denied by rule 'puppetlabs catalog'.")))))
+      (is (= body (str "Forbidden request: /puppet/v3/catalog/localhost (method :get)."
+                       " Please see the server logs for details.")))))
   (testing "Evaluation against rule with 'method' restrictions"
     (let [app (build-ring-handler default-rules)]
       (let [req (request "/puppet-ca/v1/certificate_request/ca"


### PR DESCRIPTION
Previously, an unauthenticated client could make a request to a route
protected by TK auth and get back an error message including the IP address
and rule description. This is more information than is probably good to
provide over http, especially since it could potentially include internal IPs
of proxy servers, depending on how those are configured. This commit makes it
so that the response includes minimal information but the full information is
logged server-side.
