### PR TITLE
(SERVER-1310) Use standard errors

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -32,7 +32,7 @@
 
                  [puppetlabs/kitchensink ~ks-version]
                  [puppetlabs/trapperkeeper ~tk-version]
-                 [puppetlabs/ring-middleware "0.3.1"]
+                 [puppetlabs/ring-middleware "1.0.0"]
                  [puppetlabs/typesafe-config "0.1.5"]
                  [puppetlabs/ssl-utils "0.8.1"]]
 

--- a/src/puppetlabs/trapperkeeper/authorization/ring_middleware.clj
+++ b/src/puppetlabs/trapperkeeper/authorization/ring_middleware.clj
@@ -5,7 +5,7 @@
             [ring.util.request :as ring-request]
             [ring.util.response :as ring-response]
             [slingshot.slingshot :as sling]
-            [puppetlabs.ring-middleware.core :as mw]
+            [puppetlabs.ring-middleware.utils :as ringutils]
             [puppetlabs.trapperkeeper.authorization.rules :as rules]
             [puppetlabs.trapperkeeper.authorization.ring :as ring]
             [puppetlabs.ssl-utils.core :as ssl-utils]
@@ -144,7 +144,7 @@
   (try
     (ring-codec/url-decode header-cert)
     (catch Exception e
-      (mw/throw-bad-request!
+      (ringutils/throw-bad-request!
        (str "Unable to URL decode the "
             header-cert-name
             " header: "
@@ -157,7 +157,7 @@
     (try
       (ssl-utils/pem->certs reader)
       (catch Exception e
-        (mw/throw-bad-request!
+        (ringutils/throw-bad-request!
          (str "Unable to parse "
               header-cert-name
               " into certificate: "
@@ -172,10 +172,10 @@
           certs      (pem->certs pem)
           cert-count (count certs)]
       (condp = cert-count
-        0 (mw/throw-bad-request!
+        0 (ringutils/throw-bad-request!
            (str "No certs found in PEM read from " header-cert-name))
         1 (first certs)
-        (mw/throw-bad-request!
+        (ringutils/throw-bad-request!
          (str "Only 1 PEM should be supplied for "
               header-cert-name
               " but "

--- a/test/puppetlabs/trapperkeeper/authorization/ring_middleware_test.clj
+++ b/test/puppetlabs/trapperkeeper/authorization/ring_middleware_test.clj
@@ -127,27 +127,27 @@
                 (cert-from-request (testutils/url-encoded-cert
                                     testutils/test-domain-cert))))))
       (testing "fails as expected when cert not properly URL encoded"
-        (is (thrown+? [:type :bad-request
-                       :message (str "Unable to URL decode the x-client-cert header: "
+        (is (thrown+? [:kind :bad-request
+                       :msg (str "Unable to URL decode the x-client-cert header: "
                                      "For input string: \"1%\"")]
                       (cert-from-request "%1%2"))))
       (testing "fails as expected when URL encoded properly but base64 content malformed"
-        (is (thrown+? [:type :bad-request
-                       :message (str "Unable to parse x-client-cert into "
+        (is (thrown+? [:kind :bad-request
+                       :msg (str "Unable to parse x-client-cert into "
                                      "certificate: -----END CERTIFICATE not found")]
                       (cert-from-request
                        "-----BEGIN%20CERTIFICATE-----%0AM"))))
       (testing "fails when cert not in the payload"
-        (is (thrown+? [:type :bad-request
-                       :message "No certs found in PEM read from x-client-cert"]
+        (is (thrown+? [:kind :bad-request
+                       :msg "No certs found in PEM read from x-client-cert"]
                       (cert-from-request "NOCERTSHERE"))))
       (testing "fails when more than one cert is in the payload"
         (let [cert-writer (StringWriter.)
               _ (ssl-utils/cert->pem! testutils/test-domain-cert cert-writer)
               _ (ssl-utils/cert->pem! testutils/test-domain-cert cert-writer)
               certs-encoded (ring-codec/url-encode cert-writer)]
-          (is (thrown+? [:type :bad-request
-                         :message (str "Only 1 PEM should be supplied for "
+          (is (thrown+? [:kind :bad-request
+                         :msg (str "Only 1 PEM should be supplied for "
                                        "x-client-cert but 2 found")]
                         (cert-from-request certs-encoded))))))))
 


### PR DESCRIPTION
This moves us to the standard error format described in the [nogui](https://github.com/puppetlabs/puppet-nogui/blob/master/patterns/api_style_guide.md#errors) repo.

~~This is currently Do Not Merge [DNM] prep for after we have released ring-middleware 0.4.0.~~
We will also need to:
- [x] Update this to pull in the newest ring-middleware
- [x] Potentially update this for the reorg of helpers in ring-middleware into a utils namespace (not sure if that will land in 0.4.0).
