### PR TITLE
(TK-430) Migrate to clj-parent 0.3.3 and bump i18n to 0.6.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: clojure
-lein: lein2
+lein: 2.7.1
 jdk:
   - oraclejdk7
   - openjdk7

--- a/project.clj
+++ b/project.clj
@@ -1,38 +1,30 @@
-(def ks-version "1.3.1")
-(def tk-version "1.4.0")
-(def tk-jetty-version "1.4.1")
-
 (defproject puppetlabs/trapperkeeper-authorization "0.7.1-SNAPSHOT"
   :description "Trapperkeeper authorization system"
   :url "http://github.com/puppetlabs/trapperkeeper-authorization"
   :license {:name "Apache License, Version 2.0"
             :url "http://www.apache.org/licenses/LICENSE-2.0.html"}
 
+  :min-lein-version "2.7.1"
+
+  :parent-project {:coords [puppetlabs/clj-parent "0.3.3"]
+                   :inherit [:managed-dependencies]}
+
   ;; Abort when version ranges or version conflicts are detected in
   ;; dependencies. Also supports :warn to simply emit warnings.
   ;; requires lein 2.2.0+.
   :pedantic? :abort
 
-  :dependencies [[org.clojure/clojure "1.7.0"]
-                 ;; begin version conflict resolution dependencies
-                 [clj-time "0.11.0"]
-                 [ring/ring-servlet "1.4.0"]
-                 [slingshot "0.12.2"]
-                 [cheshire "5.6.1"]
-                 [org.slf4j/slf4j-api "1.7.13"]
-                 [org.clojure/tools.reader "1.0.0-alpha1"]
-                 ;; end version conflict resolution dependencies
+  :dependencies [[org.clojure/clojure]
+                 [org.clojure/tools.logging]
+                 [slingshot]
+                 [prismatic/schema]
+                 [ring-mock]
 
-                 [org.clojure/tools.logging "0.3.1"]
-                 [prismatic/schema "1.1.1"]
-                 [ring/ring-core "1.4.0"]
-                 [ring/ring-mock "0.3.0"]
-
-                 [puppetlabs/kitchensink ~ks-version]
-                 [puppetlabs/trapperkeeper ~tk-version]
-                 [puppetlabs/ring-middleware "1.0.0"]
-                 [puppetlabs/ssl-utils "0.8.1"]
-                 [puppetlabs/i18n "0.4.3"]]
+                 [puppetlabs/kitchensink]
+                 [puppetlabs/trapperkeeper]
+                 [puppetlabs/ring-middleware]
+                 [puppetlabs/ssl-utils]
+                 [puppetlabs/i18n]]
 
   ;; By declaring a classifier here and a corresponding profile below we'll get an additional jar
   ;; during `lein jar` that has all the code in the test/ directory. Downstream projects can then
@@ -45,16 +37,14 @@
                               "-b" "./examples/ring_app/bootstrap.cfg"
                               "-c" "./examples/ring_app/ring-example.conf"]}
                    :source-paths ["examples/ring_app/src"]
-                   :dependencies [[puppetlabs/trapperkeeper-webserver-jetty9 ~tk-jetty-version]
-                                  [puppetlabs/trapperkeeper ~tk-version :classifier "test" :scope "test"]
-                                  [puppetlabs/kitchensink ~ks-version :classifier "test"]
-                                  [org.clojure/tools.namespace "0.2.10"]]}
+                   :dependencies [[puppetlabs/trapperkeeper-webserver-jetty9]
+                                  [puppetlabs/trapperkeeper nil :classifier "test" :scope "test"]
+                                  [puppetlabs/kitchensink nil :classifier "test" :scope "test"]]}
              :testutils {:source-paths ^:replace ["test"]}}
 
   ;; this plugin is used by jenkins jobs to interrogate the project version
-  :plugins [[lein-project-version "0.1.0"]
-            [lein-release "1.0.5" :exclusions [org.clojure/clojure]]
-            [puppetlabs/i18n "0.4.3"]]
+  :plugins [[lein-parent "0.3.1"]
+            [puppetlabs/i18n "0.6.0"]]
 
   :lein-release        {:scm          :git
                         :deploy-via   :lein-deploy}


### PR DESCRIPTION
This commit migrates tk-auth to using clj-parent version 0.3.3 for its
dependencies.  This commit also updates the i18n plugin dependency from
0.4.3 to 0.6.0 for compatibility with the version of i18n being
inherited from clj-parent.