### PR TITLE
(TK-478) Add rbac rule to ACL schema

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: clojure
-lein: 2.7.1
+lein: 2.8.1
 jdk:
-  - oraclejdk7
-  - openjdk7
+  - openjdk11
+  - openjdk8
 script: ./ext/travisci/test.sh
 notifications:
   email: false

--- a/project.clj
+++ b/project.clj
@@ -26,6 +26,7 @@
 
                  [puppetlabs/kitchensink]
                  [puppetlabs/trapperkeeper]
+                 [puppetlabs/rbac-client]
                  [puppetlabs/ring-middleware]
                  [puppetlabs/ssl-utils]
                  [puppetlabs/i18n]]

--- a/src/puppetlabs/trapperkeeper/authorization/ring_middleware.clj
+++ b/src/puppetlabs/trapperkeeper/authorization/ring_middleware.clj
@@ -243,14 +243,14 @@
         (assoc request :rbac-subject (token->subject token))
         (catch [:kind :puppetlabs.rbac/token-revoked] {:keys [msg]}
           (log/error "Failure validating RBAC token:" msg)
-          request)
+          (assoc request :rbac-error msg))
         (catch [:kind :puppetlabs.rbac/token-expired] {:keys [msg]}
           (log/error "Failure validating RBAC token:" msg)
-          request)
+          (assoc request :rbac-error msg))
         (catch [:kind :puppetlabs.rbac-client/connection-failure] {:keys [msg]}
           (log/error "Failure validating RBAC token:" msg)
-          request))
-        request)
+          (assoc request :rbac-error msg)))
+      request)
     request))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/src/puppetlabs/trapperkeeper/authorization/rules.clj
+++ b/src/puppetlabs/trapperkeeper/authorization/rules.clj
@@ -161,9 +161,13 @@
 (defn- request->resp-description
   [request rule]
   (let [path (:uri request)
-        method (:request-method request)]
-    (tru "Forbidden request: {0} (method {1}). Please see the server logs for details."
-         path method)))
+        method (:request-method request)
+        rbac-message (:rbac-error request)]
+    (if rbac-message
+      (tru "Forbidden request: {0} (method {1}). RBAC Message: {2} Please see the server logs for details."
+         path method rbac-message)
+      (tru "Forbidden request: {0} (method {1}). Please see the server logs for details."
+         path method))))
 
 (schema/defn allow-request :- AuthorizationResult
   "Logs debugging information about the request and rule at the TRACE level

--- a/src/puppetlabs/trapperkeeper/authorization/rules.clj
+++ b/src/puppetlabs/trapperkeeper/authorization/rules.clj
@@ -1,11 +1,11 @@
 (ns puppetlabs.trapperkeeper.authorization.rules
   (:require [clojure.tools.logging :as log]
-            [puppetlabs.ssl-utils.core :refer [get-extensions]]
+            [puppetlabs.i18n.core :refer [trs tru]]
             [puppetlabs.trapperkeeper.authorization.acl :as acl]
             [puppetlabs.trapperkeeper.authorization.ring :as ring]
-            [schema.core :as schema]
-            [puppetlabs.i18n.core :refer [trs tru]])
-  (:import java.util.regex.Pattern))
+            [schema.core :as schema])
+  (:import clojure.lang.IFn
+           java.util.regex.Pattern))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;; Schemas
@@ -210,19 +210,21 @@
    will be checked in the given order; use `sort-rules` to first sort them."
   ([rules :- [Rule]
     request :- ring/Request]
-   (allowed? rules {} request))
+   (allowed? rules {} nil request))
   ([rules :- [Rule]
     oid-map :- acl/OIDMap
+    rbac-is-permitted? :- (schema/maybe IFn)
     request :- ring/Request]
    (if-let [{:keys [rule matches]} (some #(match? % request) rules)]
      (if (true? (:allow-unauthenticated rule))
        (allow-request request rule "allow-unauthenticated is true - allowed")
-       (if (and (true? (ring/authorized-authenticated request))
-                (acl/allowed? (:acl rule)
-                              {:certname (ring/authorized-name request)
-                               :extensions (ring/authorized-extensions request)}
-                              {:oid-map oid-map
-                               :captures matches}))
+       (if (or (and (true? (ring/authorized-authenticated request))
+                    (acl/allowed? (:acl rule)
+                                  {:certname (ring/authorized-name request)
+                                   :extensions (ring/authorized-extensions request)}
+                                  {:oid-map oid-map
+                                   :captures matches}))
+               (acl/rbac-allowed? (:acl rule) (:rbac-subject request) rbac-is-permitted?))
          (allow-request request rule "")
          (deny-request request rule (request->log-description request rule)
                        (request->resp-description request rule))))

--- a/src/puppetlabs/trapperkeeper/services/authorization/authorization_core.clj
+++ b/src/puppetlabs/trapperkeeper/services/authorization/authorization_core.clj
@@ -38,7 +38,7 @@
 
   (when (:rbac config-value)
     (when-not (nil? (schema/check acl/RBACRule (:rbac config-value)))
-      (reject! (trs "permission key should map to a string; got ''{0}''" (:rbac config-value)))))
+      (reject! (trs "permission key should map to a string of form ''object_type:action:instance''; got ''{0}''" (:rbac config-value)))))
 
   (when (or (not (or (:extensions config-value) (:certname config-value) (:rbac config-value)))
             (and (:extensions config-value) (:certname config-value)))

--- a/src/puppetlabs/trapperkeeper/services/authorization/authorization_core.clj
+++ b/src/puppetlabs/trapperkeeper/services/authorization/authorization_core.clj
@@ -36,9 +36,13 @@
     (when-not (nil? (schema/check schema/Str (:certname config-value)))
       (reject! (trs "certname key should map to a string; got ''{0}''" (:certname config-value)))))
 
-  (when (or (not (or (:extensions config-value) (:certname config-value)))
+  (when (:rbac config-value)
+    (when-not (nil? (schema/check acl/RBACRule (:rbac config-value)))
+      (reject! (trs "permission key should map to a string; got ''{0}''" (:rbac config-value)))))
+
+  (when (or (not (or (:extensions config-value) (:certname config-value) (:rbac config-value)))
             (and (:extensions config-value) (:certname config-value)))
-    (reject! (trs "ACL Definition must contain exactly one of ''certname'' or ''extensions'' keys; got ''{0}''" config-value))))
+    (reject! (trs "ACL Definition must contain exactly one of ''certname'' or ''extensions'' or ''rbac'' keys; got ''{0}''" config-value))))
 
 (schema/defn canonicalize-acl :- acl/ACEConfig
   [config-value]

--- a/src/puppetlabs/trapperkeeper/services/authorization/authorization_service.clj
+++ b/src/puppetlabs/trapperkeeper/services/authorization/authorization_service.clj
@@ -7,6 +7,7 @@
             [puppetlabs.kitchensink.core :as ks]
             [puppetlabs.trapperkeeper.services.authorization.authorization-core :refer :all]
             [puppetlabs.trapperkeeper.services :refer [service-context]]
+            [puppetlabs.rbac-client.protocols.rbac :refer [RbacConsumerService]]
             [puppetlabs.i18n.core :refer [trs]]))
 
 (defprotocol AuthorizationService
@@ -15,7 +16,8 @@
 
 (defservice authorization-service
   AuthorizationService
-  [[:ConfigService get-in-config]]
+  {:required [[:ConfigService get-in-config]]
+   :optional [RbacConsumerService]}
   (init
    [this context]
    (let [config (get-in-config [:authorization])

--- a/src/puppetlabs/trapperkeeper/services/authorization/authorization_service.clj
+++ b/src/puppetlabs/trapperkeeper/services/authorization/authorization_service.clj
@@ -1,14 +1,23 @@
 (ns puppetlabs.trapperkeeper.services.authorization.authorization-service
   (:require [clojure.tools.logging :as log]
+            [puppetlabs.i18n.core :refer [trs]]
+            [puppetlabs.kitchensink.core :as ks]
+            [puppetlabs.rbac-client.protocols.rbac
+             :as
+             rbac
+             :refer
+             [RbacConsumerService]]
             [puppetlabs.ring-middleware.core :as mw]
-            [puppetlabs.trapperkeeper.authorization.ring-middleware :as
+            [puppetlabs.trapperkeeper.authorization.ring-middleware
+             :as
              ring-middleware]
             [puppetlabs.trapperkeeper.core :refer [defservice]]
-            [puppetlabs.kitchensink.core :as ks]
-            [puppetlabs.trapperkeeper.services.authorization.authorization-core :refer :all]
-            [puppetlabs.trapperkeeper.services :refer [service-context]]
-            [puppetlabs.rbac-client.protocols.rbac :refer [RbacConsumerService]]
-            [puppetlabs.i18n.core :refer [trs]]))
+            [puppetlabs.trapperkeeper.services
+             :refer
+             [maybe-get-service service-context]]
+            [puppetlabs.trapperkeeper.services.authorization.authorization-core
+             :refer
+             :all]))
 
 (defprotocol AuthorizationService
   (wrap-with-authorization-check [this handler] [this handler options])
@@ -21,9 +30,15 @@
   (init
    [this context]
    (let [config (get-in-config [:authorization])
-         rules (-> config validate-auth-config! :rules transform-config)]
+         rules (-> config validate-auth-config! :rules transform-config)
+         is-permitted? (if-let [rbac-service (maybe-get-service this :RbacConsumerService)]
+                         (partial rbac/is-permitted? rbac-service))
+         token->subject (if-let [rbac-service (maybe-get-service this :RbacConsumerService)]
+                          (partial rbac/valid-token->subject rbac-service))]
      (log/debug (trs "Transformed auth.conf rules:\n{0}") (ks/pprint-to-string rules))
      (-> context
+         (assoc :is-permitted? is-permitted?)
+         (assoc :token->subject token->subject)
          (assoc-in [:rules] rules)
          (assoc-in [:allow-header-cert-info] (get config
                                                   :allow-header-cert-info
@@ -33,8 +48,8 @@
    (authorization-check this request {:oid-map {}}))
 
   (authorization-check [this request {:keys [oid-map]}]
-   (let [{:keys [rules allow-header-cert-info]} (service-context this)]
-    (ring-middleware/authorization-check request rules oid-map allow-header-cert-info)))
+   (let [{:keys [rules allow-header-cert-info is-permitted? token->subject]} (service-context this)]
+    (ring-middleware/authorization-check request rules oid-map allow-header-cert-info is-permitted? token->subject)))
 
   (wrap-with-authorization-check
    [this handler]
@@ -42,7 +57,7 @@
 
   (wrap-with-authorization-check
    [this handler {:keys [oid-map]}]
-   (let [{:keys [allow-header-cert-info rules]} (service-context this)]
+   (let [{:keys [allow-header-cert-info rules is-permitted? token->subject]} (service-context this)]
      (-> handler
-         (ring-middleware/wrap-authorization-check rules oid-map allow-header-cert-info)
+         (ring-middleware/wrap-authorization-check rules oid-map allow-header-cert-info is-permitted? token->subject)
          (mw/wrap-bad-request :plain)))))

--- a/test/puppetlabs/trapperkeeper/authorization/acl_test.clj
+++ b/test/puppetlabs/trapperkeeper/authorization/acl_test.clj
@@ -2,6 +2,7 @@
   (:require [clojure.test :refer :all]
             [puppetlabs.trapperkeeper.authorization.acl :as acl]
             [clojure.string :as str]
+            [slingshot.test :refer :all]
             [schema.test :as schema-test]))
 
 (use-fixtures :once schema-test/validate-schemas)
@@ -225,3 +226,13 @@
       (is (acl/rbac-allowed? acl "good" is-permitted?)))
     (testing "denies"
       (is (not (acl/rbac-allowed? acl "bad" is-permitted?))))))
+
+(deftest test-bad-rbac-rules
+  (testing "deny ACE with rbac permission throws"
+    (is (thrown+?
+         [:kind :rbac-deny
+          :msg "RBAC permissions cannot be used to deny access. Permission: 'keep:me:out'"]
+         (acl/new-domain :deny {:rbac {:permission "keep:me:out"}}))))
+
+  (testing "RBAC permission string formatted wrong"
+    (is (thrown? RuntimeException (acl/new-domain :allow {:rbac {:permission "badpermission"}})))))

--- a/test/puppetlabs/trapperkeeper/authorization/acl_test.clj
+++ b/test/puppetlabs/trapperkeeper/authorization/acl_test.clj
@@ -216,3 +216,12 @@
         (is (!allowed? (challenge "new.confessional.org" {:style "slam" :author "plath"})))
         (is (!allowed? (challenge "new.confessional.org" {:style "sonnet" :author "gioia"})))
         (is (!allowed? (challenge "neo.formalism.com" {:style "haiku" :author "plath"})))))))
+
+(deftest test-rbac-allowed
+  (let [is-permitted? (fn [subject permission] (and (= permission "let:me:in") (= subject "good")))
+        acl #{(acl/new-domain :allow {:rbac {:permission "12:34:56"}})
+              (acl/new-domain :allow {:rbac {:permission "let:me:in"}})}]
+    (testing "allows"
+      (is (acl/rbac-allowed? acl "good" is-permitted?)))
+    (testing "denies"
+      (is (not (acl/rbac-allowed? acl "bad" is-permitted?))))))

--- a/test/puppetlabs/trapperkeeper/authorization/ring_middleware_test.clj
+++ b/test/puppetlabs/trapperkeeper/authorization/ring_middleware_test.clj
@@ -362,7 +362,7 @@
           cert (testutils/create-certificate "tea.leaves.thwart.net" exts)
 
           req (testutils/request "/foo/bar" :get "127.0.0.1" cert)
-          auth-check (fn [rules] (ring-middleware/authorization-check req rules oid-map false))]
+          auth-check (fn [rules] (ring-middleware/authorization-check req rules oid-map false nil nil))]
 
 
       (testing "extensions are set properly"

--- a/test/puppetlabs/trapperkeeper/authorization/rules_test.clj
+++ b/test/puppetlabs/trapperkeeper/authorization/rules_test.clj
@@ -131,19 +131,19 @@
         (let [rules (build-rules ["/path/to/resource" "*.domain.org"]
                                  ["/stairway/to/heaven" "*.domain.org"])
               request (ring/set-authorized-name request "test.domain.org")]
-          (is (rules/authorized? (rules/allowed? rules request)))))
+          (is (rules/authorized? (rules/allowed? request rules {} nil)))))
       (testing "global deny"
         (let [rules (build-rules ["/path/to/resource" "*.domain.org"]
                                  ["/path/to/other" "*.domain.org"])
               request (ring/set-authorized-name request "www.domain.org")]
-          (is (not (rules/authorized? (rules/allowed? rules request))))
-          (is (= (:message (rules/allowed? rules request))
+          (is (not (rules/authorized? (rules/allowed? request rules {} nil))))
+          (is (= (:message (rules/allowed? request rules {} nil))
                  "global deny all - no rules matched"))))
       (testing "rule not allowing"
         (let [rules (build-rules ["/path/to/resource" "*.domain.org"]
                                  ["/stairway/to/heaven" "*.domain.org"])
               request (ring/set-authorized-name request "www.test.org")
-              rules-allowed (rules/allowed? rules request)]
+              rules-allowed (rules/allowed? request rules {} nil)]
           (is (not (rules/authorized? rules-allowed )))
           (is (= (:message rules-allowed)
                  (str "Forbidden request: /stairway/to/heaven (method :get)."
@@ -158,7 +158,7 @@
                          (build-rules ["/path/to/resource" "*.domain.org"]
                                       ["/stairway/to/heaven" "*.domain.org"]))
               request (ring/set-authorized-name request "www.test.org")
-              rules-allowed (rules/allowed? rules request)]
+              rules-allowed (rules/allowed? request rules {} nil)]
           (is (not (rules/authorized? rules-allowed)))
           (is (= (:message rules-allowed)
                  (str "Forbidden request: /stairway/to/heaven (method :get)."
@@ -179,7 +179,7 @@
           request (-> (testutils/request "/foo")
                       (ring/set-authorized-authenticated true)
                       (ring/set-authorized-name "test.org"))]
-      (is (rules/authorized? (rules/allowed? rules request)))))
+      (is (rules/authorized? (rules/allowed? request rules {} nil)))))
   (testing "rules checked in order of name when sort-order is the same"
     (let [rules (rules/sort-rules
                  [(-> (rules/new-rule :path "/foo" :any 1 "bbb")
@@ -189,4 +189,4 @@
           request (-> (testutils/request "/foo")
                       (ring/set-authorized-authenticated true)
                       (ring/set-authorized-name "test.org"))]
-      (is (rules/authorized? (rules/allowed? rules request))))))
+      (is (rules/authorized? (rules/allowed? request rules {} nil))))))

--- a/test/puppetlabs/trapperkeeper/services/authorization/authorization_service_test.clj
+++ b/test/puppetlabs/trapperkeeper/services/authorization/authorization_service_test.clj
@@ -9,10 +9,12 @@
     [puppetlabs.trapperkeeper.services :refer [defservice]]
     [puppetlabs.trapperkeeper.services.authorization.authorization-service
      :refer [authorization-service]]
+    [puppetlabs.rbac-client.protocols.rbac :refer [RbacConsumerService]]
     [puppetlabs.trapperkeeper.testutils.bootstrap :refer [with-app-with-config]]
     [puppetlabs.trapperkeeper.testutils.logging :refer [with-test-logging]]
     [ring.mock.request :as mock]
     [ring.util.response :refer [response]]
+    [slingshot.slingshot :refer [throw+]]
     [schema.test :as schema-test])
   (:import (java.io ByteArrayInputStream)
            (java.nio.charset Charset)))
@@ -110,7 +112,14 @@
      :type   "path"}
     :allow-unauthenticated true
     :sort-order 500
-    :name "puppetlabs csr"}])
+    :name "puppetlabs csr"}
+   {:match-request
+    {:path "/puppet/v3/rbac_test"
+     :method "get"
+     :type "path"}
+    :allow {:rbac {:permission "get:test:*"}}
+    :sort-order 500
+    :name "rbac-test"}])
 
 (def catalog-request-nocert
   "A basic request for a catalog without a valid SSL cert"
@@ -145,6 +154,39 @@
                        (assoc :request req)))]
      (wrap-with-authorization-check handler))))
 
+(defservice dummy-rbac-service
+  RbacConsumerService
+  []
+  (is-permitted? [this subject perm-str] true)
+  (are-permitted? [this subject perm-strs]
+    (vec (repeat (count perm-strs) true)))
+  (cert-whitelisted? [this ssl-client-cn] true)
+  (cert->subject [this ssl-client-cn]
+    {:id #uuid "af94921f-bd76-4b58-b5ce-e17c029a2790"
+     :login "api_user"})
+  (valid-token->subject [this jwt-str]
+    (if (or (not jwt-str) (= "invalid-token" jwt-str))
+      (throw+ {:kind :puppetlabs.rbac/invalid-token
+               :msg (format "Token: %s" jwt-str)})
+      {:login     "test_user"
+       :id        #uuid "751a8f7e-b53a-4ccd-9f4f-e93db6aa38ec"
+       :group_ids [#uuid "aaaaaaaa-b53a-4ccd-9f4f-e93db6aa38ec"
+                   #uuid "bbbbbbbb-b53a-4ccd-9f4f-e93db6aa38ec"]}))
+  (status [this level]
+    {:service_version "1.2.12",
+     :service_status_version 1,
+     :detail_level "info",
+     :state :running,
+     :status {:db_up true,
+              :activity_up true}})
+  (list-permitted [this token object-type action]
+    ["one", "two", "three"])
+  (list-permitted-for [this subject object-type action]
+    ["four" "five" "six"])
+  (subject [this user-id]
+    {:id user-id
+     :login "anImaginaryUserForTesting"}))
+
 (defn build-ring-handler
   "Build a ring handler around the echo reverse service"
   ([rules]
@@ -154,7 +196,7 @@
      (with-test-logging
       (with-app-with-config
        app
-       [echo-reverse-service authorization-service]
+       [echo-reverse-service authorization-service dummy-rbac-service]
        (assoc-in config [:authorization :rules] rules)
        (let [svc (get-service app :EchoReverseService)
              echo-handler (echo-reverse svc "Prefix: ")]
@@ -428,7 +470,7 @@
       (with-test-logging
         (with-app-with-config
           app
-          [plumbing-service authorization-service]
+          [plumbing-service authorization-service dummy-rbac-service]
           (assoc-in minimal-config [:authorization :rules] rules-w-exts)
           (testing "allowed request via extensions"
             (let [req (testutils/request "/puppet/v4/catalog" :get "127.0.0.1" allowable-cert)]
@@ -501,7 +543,7 @@
         (with-test-logging
           (with-app-with-config
             app
-            [plumbing-service authorization-service]
+            [plumbing-service authorization-service dummy-rbac-service]
             (assoc-in minimal-config [:authorization :rules] ext-rules)
             (testing "with allow rule"
               (let [req (testutils/request "/puppet/v4/catalog" :get "127.0.0.1" allowable-cert)]
@@ -518,7 +560,7 @@
         (with-test-logging
           (with-app-with-config
             app
-            [plumbing-service authorization-service]
+            [plumbing-service authorization-service dummy-rbac-service]
             (assoc-in minimal-config [:authorization :rules] certname-rules)
             (testing "using allowed glob"
               (let [req (testutils/request "/puppet/v5/catalog" :get "127.0.0.1" allowable-cert)]


### PR DESCRIPTION
These commits update the schema for the ACL, represented as HOCON in auth.conf, to support a new map for allowing and denying.
```
allow: { rbac: { permission: "object:action:instance" } }
```

It does not currently check anything based on this rule.