### PR TITLE
(maint) Fix dummy-rbac-service definition

### DIFF
--- a/test/puppetlabs/trapperkeeper/services/authorization/authorization_service_test.clj
+++ b/test/puppetlabs/trapperkeeper/services/authorization/authorization_service_test.clj
@@ -161,6 +161,7 @@
   (are-permitted? [this subject perm-strs]
     (vec (repeat (count perm-strs) true)))
   (cert-whitelisted? [this ssl-client-cn] true)
+  (cert-allowed? [this ssl-client-cn] true)
   (cert->subject [this ssl-client-cn]
     {:id #uuid "af94921f-bd76-4b58-b5ce-e17c029a2790"
      :login "api_user"})


### PR DESCRIPTION
This fixes a testsuite failure:

```
Syntax error macroexpanding puppetlabs.trapperkeeper.services/service at (puppetlabs/trapperkeeper/services/authorization/authorization_service_test.clj:157:1).
Service does not define function 'cert-allowed?', which is required by protocol 'RbacConsumerService'

Full report at:
/tmp/clojure-9972041018184146329.edn
Tests failed.
```