### PR TITLE
(maint) update dependencies, prepare for 2.0.0 release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: clojure
-lein: 2.8.1
+lein: 2.10.0
 jdk:
+  - openjdk17
   - openjdk11
-  - openjdk8
 script: ./ext/travisci/test.sh
 notifications:
   email: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+### 2.0.0
+  * Require java 11 or 17 (clj-parent 5.3.0, bouncycastle test dependencies)
+  * Update clj-parent to 5.3.0 to modernize the dependencies
+  * Move ring-mock into the dev dependencies
+  * Remove dependency on n-repl
+  * Adds ring-codec as a dependency (it was moved out of ring-core in 1.2)
+  * Changes a test expectation since ring-codec no longer uses java URL Decoder
+  * fix for clj-rbac-client dependency (Thanks @jcharaou!)
+
 ### 1.0.0
 
   * [TK-474](https://tickets.puppetlabs.com/browse/TK-474) Support

--- a/project.clj
+++ b/project.clj
@@ -6,7 +6,7 @@
 
   :min-lein-version "2.7.1"
 
-  :parent-project {:coords [puppetlabs/clj-parent "2.4.1"]
+  :parent-project {:coords [puppetlabs/clj-parent "5.3.0"]
                    :inherit [:managed-dependencies]}
 
   ;; Abort when version ranges or version conflicts are detected in
@@ -16,13 +16,10 @@
 
   :dependencies [[org.clojure/clojure]
 
-                 ;; See SERVER-2216
-                 [org.clojure/tools.nrepl "0.2.13"]
-
                  [org.clojure/tools.logging]
                  [slingshot]
                  [prismatic/schema]
-                 [ring/ring-mock]
+                 [ring/ring-codec]
 
                  [puppetlabs/kitchensink]
                  [puppetlabs/trapperkeeper]
@@ -45,12 +42,15 @@
                    :dependencies [[puppetlabs/trapperkeeper-webserver-jetty9]
                                   [puppetlabs/trapperkeeper nil :classifier "test" :scope "test"]
                                   [puppetlabs/kitchensink nil :classifier "test" :scope "test"]
-                                  [org.clojure/tools.namespace "0.2.11"]]}
+                                  [org.clojure/tools.namespace "1.4.1"]
+                                  [org.bouncycastle/bcprov-jdk18on]
+                                  [org.bouncycastle/bcpkix-jdk18on]
+                                  [ring/ring-mock]]}
              :testutils {:source-paths ^:replace ["test"]}}
 
   ;; this plugin is used by jenkins jobs to interrogate the project version
-  :plugins [[lein-parent "0.3.1"]
-            [puppetlabs/i18n "0.8.0"]]
+  :plugins [[lein-parent "0.3.9"]
+            [puppetlabs/i18n "0.9.3"]]
 
   :lein-release        {:scm          :git
                         :deploy-via   :lein-deploy}

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject puppetlabs/trapperkeeper-authorization "1.0.1-SNAPSHOT"
+(defproject puppetlabs/trapperkeeper-authorization "2.0.0-SNAPSHOT"
   :description "Trapperkeeper authorization system"
   :url "http://github.com/puppetlabs/trapperkeeper-authorization"
   :license {:name "Apache License, Version 2.0"
@@ -50,7 +50,7 @@
 
   ;; this plugin is used by jenkins jobs to interrogate the project version
   :plugins [[lein-parent "0.3.9"]
-            [puppetlabs/i18n "0.9.3"]]
+            [puppetlabs/i18n "0.9.2"]]
 
   :lein-release        {:scm          :git
                         :deploy-via   :lein-deploy}

--- a/test/puppetlabs/trapperkeeper/authorization/ring_middleware_test.clj
+++ b/test/puppetlabs/trapperkeeper/authorization/ring_middleware_test.clj
@@ -128,8 +128,7 @@
                                     testutils/test-domain-cert))))))
       (testing "fails as expected when cert not properly URL encoded"
         (is (thrown+? [:kind :bad-request
-                       :msg (str "Unable to URL decode the x-client-cert header: "
-                                     "For input string: \"1%\"")]
+                       :msg "No certs found in PEM read from x-client-cert"]
                       (cert-from-request "%1%2"))))
       (testing "fails as expected when URL encoded properly but base64 content malformed"
         (is (thrown+? [:kind :bad-request


### PR DESCRIPTION
First commit:

This updates clj-parent which brings in new versions of clj-rbac-client,
trapperkeeper, slingshot, prismatic/schema, kitchensink, ring-middleware,
ssl-urls and i18n.

Additionally ring-mock was moved into the dev-dependencies, and bouncycastle
was added as dev-dependencies for trapperkeeper-webserver-jetty9.

Clojure tools namespace was also updated to 1.4.1

At the time of the last update ring-codec was part of the ring-core
library and depended on java url decode for its implementation.  Since
then, it was moved into a separate ring-codec library and the implementation
changed to a more simple percent-encoding implementation. As a result,
there are no longer exceptions thrown by invalid encodings. A test that
was trying to detect that invalid decoding was changes to instead reflect
the new behavior.

Second commit:

This prepares for a 2.0.0 release. This release is no longer claimed
to be compatible with java 8, and thus the major version number change.

