### PR TITLE
(maint) improve warning logging message

### DIFF
--- a/src/puppetlabs/trapperkeeper/authorization/ring_middleware.clj
+++ b/src/puppetlabs/trapperkeeper/authorization/ring_middleware.clj
@@ -59,8 +59,8 @@
   "Log a warning message if the supplied common-name is empty (nil or empty
   string."
   [common-name empty-message]
-  (if (empty? common-name)
-    (log/warnf (format "%s  %s" empty-message (trs "Treating client as ''unauthenticated''."))))
+  (when (empty? common-name)
+    (log/warn (trs "{0} Treating client as ''unauthenticated''." empty-message)))
   common-name)
 
 (defn request->name*


### PR DESCRIPTION
A warning logging message was using multiple levels of formatting, and a log method that expected to format as well.  This updates the method to use one type of formatting.