### PR TITLE
(PE-36769) remove header warning from request->cert

### DIFF
--- a/src/puppetlabs/trapperkeeper/authorization/ring_middleware.clj
+++ b/src/puppetlabs/trapperkeeper/authorization/ring_middleware.clj
@@ -183,9 +183,7 @@
   (let [header-cert-val (get-in request [:headers header-cert-name])]
     (if allow-header-cert-info
       (header->cert header-cert-val)
-      (do
-        (warn-if-header-value-non-nil header-cert-name header-cert-val)
-        (:ssl-client-cert request)))))
+      (:ssl-client-cert request))))
 
 (schema/defn request->extensions :- acl/Extensions
   "Given a request, return a map of shortname -> value for all of the extensions


### PR DESCRIPTION
This commit removes a warning log entry for the presense of a cert in the request header when allow-header-cert-info is false.

This particular logging was deemed not terribly useful in general, and the fix for agent auto-renew when CA proxy is present will generate lots of log noise if it is present.