### PR TITLE
Fix test for modified error message with new Bouncy Castle

### DIFF
--- a/test/puppetlabs/trapperkeeper/authorization/ring_middleware_test.clj
+++ b/test/puppetlabs/trapperkeeper/authorization/ring_middleware_test.clj
@@ -132,9 +132,11 @@
                                      "For input string: \"1%\"")]
                       (cert-from-request "%1%2"))))
       (testing "fails as expected when URL encoded properly but base64 content malformed"
-        (is (thrown+? [:kind :bad-request
-                       :msg (str "Unable to parse x-client-cert into "
-                                     "certificate: -----END CERTIFICATE not found")]
+        (is (thrown+? #(and
+                (= (:kind %) :bad-request)
+                (re-matches
+                  #"Unable to parse x-client-cert into certificate: -----END CERTIFICATE(-----)? not found"
+                  (:msg %)))
                       (cert-from-request
                        "-----BEGIN%20CERTIFICATE-----%0AM"))))
       (testing "fails when cert not in the payload"


### PR DESCRIPTION
This is a backport of a patch that was merged to Puppet Server for the same reason: https://github.com/puppetlabs/puppetserver/commit/2e5af507781b192142b179557f25655e37227e33